### PR TITLE
Use iOS 13 QRCodeGenerator

### DIFF
--- a/Examples/iOS/ViewController.swift
+++ b/Examples/iOS/ViewController.swift
@@ -108,7 +108,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
 
     @objc func openBlog() {
         if let tryUrl = URL(string: "https://github.com/EFPrefix/EFQRCode") {
-            UIApplication.shared.openURL(tryUrl)
+            UIApplication.shared.open(tryUrl)
         }
     }
 

--- a/Examples/iOS/iOS Example.xcodeproj/project.pbxproj
+++ b/Examples/iOS/iOS Example.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		5282BD3C1FF4819200DFB36B /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5282BD3B1FF4819200DFB36B /* Tests.swift */; };
 		528EFA7422965AC80026663C /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528EFA7322965AC80026663C /* Localized.swift */; };
 		528EFA7522965AC80026663C /* Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528EFA7322965AC80026663C /* Localized.swift */; };
+		D27FDFA5235AB5DB0033ACFF /* EFFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D27FDFA4235AB5DB0033ACFF /* EFFoundation.framework */; };
+		D27FDFA6235AB5DB0033ACFF /* EFFoundation.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D27FDFA4235AB5DB0033ACFF /* EFFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +209,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				D27FDFA6235AB5DB0033ACFF /* EFFoundation.framework in Copy Frameworks */,
 				120B785E1EA3AA1100D34440 /* EFQRCode.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
@@ -293,6 +296,7 @@
 		528EFA7322965AC80026663C /* Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localized.swift; sourceTree = "<group>"; };
 		52B3BFB6229625760035D5EC /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "Resources/zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		52B3BFB7229625760035D5EC /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Interface.strings"; sourceTree = "<group>"; };
+		D27FDFA4235AB5DB0033ACFF /* EFFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EFFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E0519A951050040E7D1 /* EFQRCode.iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EFQRCode.iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -317,6 +321,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D27FDFA5235AB5DB0033ACFF /* EFFoundation.framework in Frameworks */,
 				120B785D1EA3A9FE00D34440 /* EFQRCode.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -327,6 +332,7 @@
 		120AAA922193323E00F0783B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D27FDFA4235AB5DB0033ACFF /* EFFoundation.framework */,
 				120AAA932193323E00F0783B /* swift_qrcodejs.framework */,
 			);
 			name = Frameworks;

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "EFFoundation",
+        "repositoryURL": "https://github.com/EFPrefix/EFFoundation.git",
+        "state": {
+          "branch": null,
+          "revision": "52d5533ad73ce365fae5e8e627284b0383a56179",
+          "version": "1.1.1"
+        }
+      },
+      {
         "package": "swift_qrcodejs",
         "repositoryURL": "https://github.com/ApolloZhu/swift_qrcodejs.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,9 @@ let package = Package(
                  .upToNextMinor(from: "1.1.1"))
     ],
     targets: [
-        .target(name: "EFQRCode", dependencies: ["swift_qrcodejs"], path: "Source")
+        .target(name: "EFQRCode",
+                dependencies: ["swift_qrcodejs", "EFFoundation"],
+                path: "Source")
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Source/CIImage+.swift
+++ b/Source/CIImage+.swift
@@ -26,9 +26,9 @@
 
 #if canImport(CoreImage)
 import CoreImage
+import CoreImage.CIFilterBuiltins
 
 extension CIImage {
-
     /// Get QRCode from image
     func recognizeQRCode(options: [String : Any]? = nil) -> [String] {
         var result = [String]()
@@ -43,14 +43,26 @@ extension CIImage {
     }
     
     /// Create QR CIImage
-    static func generateQRCode(string: String, inputCorrectionLevel: EFInputCorrectionLevel = .m) -> CIImage? {
-        let stringData = string.data(using: .utf8)
-        guard let qrFilter = CIFilter(name: "CIQRCodeGenerator") else {
+    static func generateQRCode(_ string: String, inputCorrectionLevel: EFInputCorrectionLevel = .m) -> CIImage? {
+        guard let stringData = string.data(using: .utf8) else {
             return nil
         }
-        qrFilter.setValue(stringData, forKey: "inputMessage")
-        qrFilter.setValue(["L", "M", "Q", "H"][inputCorrectionLevel.rawValue], forKey: "inputCorrectionLevel")
-        return qrFilter.outputImage
+        let correctionLevel = ["L", "M", "Q", "H"][inputCorrectionLevel.rawValue]
+        
+        if #available(iOS 13.0, tvOS 13.0, macOS 10.15, *) {
+            let qrFilter = CIFilter.qrCodeGenerator()
+            qrFilter.message = stringData
+            qrFilter.correctionLevel = correctionLevel
+            return qrFilter.outputImage
+        } else {
+            guard let qrFilter = CIFilter(name: "CIQRCodeGenerator") else {
+                return nil
+            }
+            qrFilter.setDefaults()
+            qrFilter.setValue(stringData, forKey: "inputMessage")
+            qrFilter.setValue(correctionLevel, forKey: "inputCorrectionLevel")
+            return qrFilter.outputImage
+        }
     }
 }
 #endif

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -694,9 +694,9 @@ public class EFQRCodeGenerator: NSObject {
         }
         let finalInputCorrectionLevel = inputCorrectionLevel
 
-        guard let tryQRImagePixels = CIImage.generateQRCode(
-            string: finalContent, inputCorrectionLevel: finalInputCorrectionLevel
-            )?.ef.cgImage?.pixels() else {
+        guard let tryQRImagePixels = CIImage
+            .generateQRCode(finalContent, inputCorrectionLevel: finalInputCorrectionLevel)?
+            .ef.cgImage?.pixels() else {
                 print("Warning: Content too large.")
                 return nil
         }


### PR DESCRIPTION
- Use type safe CIFilter when available
- Fix deprecation warning
- Add EFFoundation as dependency in Package.swift
- Fix linker error (missing EFFoundation, but why though...)

All changes should be backward compatible
