### PR TITLE
Text encoding parameter

### DIFF
--- a/Source/CIImage+.swift
+++ b/Source/CIImage+.swift
@@ -66,7 +66,7 @@ extension CIImage {
     }
     
     /// Create QR CIImage
-    static func generateQRCode(_ string: String, inputCorrectionLevel: EFInputCorrectionLevel = .m) -> CIImage? {
+    static func generateQRCode(_ string: String, using contentEncoding: String.Encoding = .utf8, inputCorrectionLevel: EFInputCorrectionLevel = .m) -> CIImage? {
         guard let stringData = string.data(using: .utf8) else {
             return nil
         }

--- a/Source/CIImage+.swift
+++ b/Source/CIImage+.swift
@@ -67,7 +67,7 @@ extension CIImage {
     
     /// Create QR CIImage
     static func generateQRCode(_ string: String, using contentEncoding: String.Encoding = .utf8, inputCorrectionLevel: EFInputCorrectionLevel = .m) -> CIImage? {
-        guard let stringData = string.data(using: .utf8) else {
+        guard let stringData = string.data(using: contentEncoding) else {
             return nil
         }
         let correctionLevel = ["L", "M", "Q", "H"][inputCorrectionLevel.rawValue]

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -76,6 +76,7 @@ public class EFQRCode: NSObject {
 
     public static func generateWithGIF(
         content: String,
+        contentEncoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = CGColor.white()!,
         foregroundColor: CGColor = CGColor.black()!,
@@ -92,6 +93,7 @@ public class EFQRCode: NSObject {
         ) -> Data? {
 
         let generator = EFQRCodeGenerator(content: content, size: size)
+        generator.setContentEncoding(encoding: contentEncoding)
         generator.setWatermark(watermark: nil, mode: watermarkMode)
         generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
         generator.setInputCorrectionLevel(inputCorrectionLevel: inputCorrectionLevel)

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -44,6 +44,7 @@ public class EFQRCode: NSObject {
     // MARK: - Generator
     public static func generate(
         content: String,
+        contentEncoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = CGColor.white()!,
         foregroundColor: CGColor = CGColor.black()!,
@@ -60,6 +61,7 @@ public class EFQRCode: NSObject {
         ) -> CGImage? {
 
         let generator = EFQRCodeGenerator(content: content, size: size)
+        generator.setContentEncoding(encoding: contentEncoding)
         generator.setWatermark(watermark: watermark, mode: watermarkMode)
         generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
         generator.setInputCorrectionLevel(inputCorrectionLevel: inputCorrectionLevel)

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -47,6 +47,17 @@ public class EFQRCodeGenerator: NSObject {
     public func setContent(content: String) {
         self.content = content
     }
+    
+    // Encoding of the content
+    private var contentEncoding: String.Encoding = .utf8 {
+        didSet {
+            imageQRCode = nil
+            imageCodes = nil
+        }
+    }
+    public func setContentEncoding(encoding: String.Encoding) {
+        self.contentEncoding = encoding
+    }
 
     // Mode of QR Code
     private var mode: EFQRCodeMode = .none {
@@ -692,9 +703,10 @@ public class EFQRCodeGenerator: NSObject {
             return nil
         }
         let finalInputCorrectionLevel = inputCorrectionLevel
+        let finalContentEncoding = contentEncoding
 
         guard let tryQRImagePixels = CIImage
-            .generateQRCode(finalContent, inputCorrectionLevel: finalInputCorrectionLevel)?
+            .generateQRCode(finalContent, using: finalContentEncoding, inputCorrectionLevel: finalInputCorrectionLevel)?
             .cgImage()?.pixels() else {
                 print("Warning: Content too large.")
                 return nil


### PR DESCRIPTION
Adds a `contentEncoding` parameter to `generateQRCode` allowing the user to specify which text encoding method to use when converting the `content` string into `Data`. The default encoding method is UTF-8, the same as the encoding method used before.

This only adds the parameter to the function and does not add an option in any of the example app interfaces.

Closes #89