### PR TITLE
Update SwiftPM section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Once you have your Swift package set up, adding EFQRCode as a dependency is as e
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/EFPrefix/EFQRCode.git", .exact("5.1.8"))
+    .package(url: "https://github.com/EFPrefix/EFQRCode.git", .upToNextMinor(from: "5.1.8"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Once you have your Swift package set up, adding EFQRCode as a dependency is as e
 
 ```swift
 dependencies: [
-    .Package(url: "https://github.com/EFPrefix/EFQRCode.git", Version(5, 1, 8))
+    .package(url: "https://github.com/EFPrefix/EFQRCode.git", .exact("5.1.8"))
 ]
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -145,7 +145,7 @@ github "EFPrefix/EFQRCode" ~> 5.1.8
 
 ```swift
 dependencies: [
-    .Package(url: "https://github.com/EFPrefix/EFQRCode.git", Version(5, 1, 8))
+    .package(url: "https://github.com/EFPrefix/EFQRCode.git", .upToNextMinor(from: "5.1.8"))
 ]
 ```
 


### PR DESCRIPTION
Modern versions of SwiftPM do not understand the old syntax (`.Package` and `Version`).