### PR TITLE
Pin swift_qrcodejs to 1.1.4

### DIFF
--- a/EFQRCode.podspec
+++ b/EFQRCode.podspec
@@ -38,6 +38,6 @@ Pod::Spec.new do |s|
   		watchos.watchos.deployment_target = '2.0'
   		
   		watchos.source_files = 'Source/**/*.{h,swift}'
-  		watchos.dependency 'swift_qrcodejs', '>= 1.1.4'
+  		watchos.dependency 'swift_qrcodejs', '1.1.4'
   	end
 end


### PR DESCRIPTION
The library needs to use version 1.1.4 of swift_qrcodejs in order to build correctly. Therefore we had to pin the dependency. Can you please publish a new version on CocoaPods?

<img width="1086" alt="Bildschirmfoto 2020-11-03 um 12 09 05" src="https://user-images.githubusercontent.com/1390908/97978231-93329900-1dcd-11eb-9c09-a6134f4b8b23.png">

Thank you.