### PR TITLE
Automate CocoaPods release

### DIFF
--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -1,0 +1,17 @@
+name: CocoaPods
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  pod:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint CocoaPods Spec
+        run: pod spec lint
+      - name: Publish to CocoaPods Trunk
+        run: pod trunk push
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Setup required: add `COCOAPODS_TRUNK_TOKEN` to secrets `github.com/EFPrefix/EFQRCode/settings/secrets`

How to obtain the token? https://fuller.li/posts/automated-cocoapods-releases-with-ci/
Remember to obtain a new token for local machine so you can revoke CI token when necessary

