### PR TITLE
[Breaking Changes] New v6 API for Swift and ObjC

### DIFF
--- a/EFQRCode.xcodeproj/project.pbxproj
+++ b/EFQRCode.xcodeproj/project.pbxproj
@@ -232,6 +232,8 @@
 		D22654B5256E965300920D11 /* ObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCTests.m; sourceTree = "<group>"; };
 		D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EFQRCode+Migration-v6.swift"; sourceTree = "<group>"; };
 		D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EFQRCode+ObjC.swift"; sourceTree = "<group>"; };
+		D2DF1DB7256EC4CF00EB6012 /* European SEPA Money Transfer + Watermark.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "European SEPA Money Transfer + Watermark.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D2DF1DB8256EC4CF00EB6012 /* Basic B&W QR Code.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Basic B&W QR Code.playground"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		F8111E3319A95C8B0040E7D1 /* EFQRCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EFQRCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8111E3E19A95C8B0040E7D1 /* EFQRCode iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "EFQRCode iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -371,6 +373,23 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		D2DF1DB5256EC4CF00EB6012 /* Playgrounds */ = {
+			isa = PBXGroup;
+			children = (
+				D2DF1DB6256EC4CF00EB6012 /* Generate */,
+			);
+			path = Playgrounds;
+			sourceTree = "<group>";
+		};
+		D2DF1DB6256EC4CF00EB6012 /* Generate */ = {
+			isa = PBXGroup;
+			children = (
+				D2DF1DB7256EC4CF00EB6012 /* European SEPA Money Transfer + Watermark.playground */,
+				D2DF1DB8256EC4CF00EB6012 /* Basic B&W QR Code.playground */,
+			);
+			path = Generate;
+			sourceTree = "<group>";
+		};
 		F8111E2919A95C8B0040E7D1 = {
 			isa = PBXGroup;
 			children = (
@@ -379,6 +398,7 @@
 				127F871E1ECF56AC0002B554 /* EFQRCode.podspec */,
 				F8111E3519A95C8B0040E7D1 /* Source */,
 				F8111E3F19A95C8B0040E7D1 /* Tests */,
+				D2DF1DB5256EC4CF00EB6012 /* Playgrounds */,
 				F8111E3419A95C8B0040E7D1 /* Products */,
 				120AAA7A21932CD300F0783B /* Frameworks */,
 				12BC19D42328B6D400B6EB5A /* swift_qrcodejs.xcodeproj */,

--- a/EFQRCode.xcodeproj/project.pbxproj
+++ b/EFQRCode.xcodeproj/project.pbxproj
@@ -100,6 +100,17 @@
 		5282BCBC1FF3903D00DFB36B /* EFQRCode+GIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12664EC41FA9CEDD00D56500 /* EFQRCode+GIF.swift */; };
 		5282BCBD1FF3903D00DFB36B /* EFQRCodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12664EC31FA9CEDD00D56500 /* EFQRCodeGenerator.swift */; };
 		8035DB621BAB492500466CB3 /* EFQRCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* EFQRCode.framework */; };
+		D22654B6256E965300920D11 /* ObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D22654B5256E965300920D11 /* ObjCTests.m */; };
+		D22654B7256E965300920D11 /* ObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D22654B5256E965300920D11 /* ObjCTests.m */; };
+		D22654B8256E965300920D11 /* ObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D22654B5256E965300920D11 /* ObjCTests.m */; };
+		D2265504256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */; };
+		D2265505256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */; };
+		D2265506256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */; };
+		D2265507256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */; };
+		D2265575256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */; };
+		D2265576256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */; };
+		D2265577256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */; };
+		D2265578256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */; };
 		F829C6B81A7A94F100A2CD59 /* EFQRCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DD67C0B1A5C55C900ED2280 /* EFQRCode.framework */; };
 /* End PBXBuildFile section */
 
@@ -218,6 +229,9 @@
 		4DD67C0B1A5C55C900ED2280 /* EFQRCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EFQRCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5282BCAD1FF38F8100DFB36B /* EFQRCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EFQRCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72998D721BF26173006D3F69 /* Info-tvOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
+		D22654B5256E965300920D11 /* ObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjCTests.m; sourceTree = "<group>"; };
+		D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EFQRCode+Migration-v6.swift"; sourceTree = "<group>"; };
+		D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EFQRCode+ObjC.swift"; sourceTree = "<group>"; };
 		F8111E3319A95C8B0040E7D1 /* EFQRCode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EFQRCode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8111E3719A95C8B0040E7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8111E3E19A95C8B0040E7D1 /* EFQRCode iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "EFQRCode iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -290,6 +304,8 @@
 				12664EC41FA9CEDD00D56500 /* EFQRCode+GIF.swift */,
 				12664EC31FA9CEDD00D56500 /* EFQRCodeGenerator.swift */,
 				12664EC21FA9CEDD00D56500 /* EFQRCodeRecognizer.swift */,
+				D2265503256E9BFF00920D11 /* EFQRCode+Migration-v6.swift */,
+				D2265574256EA35600920D11 /* EFQRCode+ObjC.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -411,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				4C256A501B096C2C0065714F /* Tests.swift */,
+				D22654B5256E965300920D11 /* ObjCTests.m */,
 				126A1B581EAF225100EFBA1B /* Resources */,
 				F8111E4019A95C8B0040E7D1 /* Supporting Files */,
 			);
@@ -607,7 +624,7 @@
 					};
 					4CF626F71BA7CB3E0011A099 = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1230;
 					};
 					4DD67C0A1A5C55C900ED2280 = {
 						CreatedOnToolsVersion = 6.1.1;
@@ -626,11 +643,11 @@
 					};
 					F8111E3D19A95C8B0040E7D1 = {
 						CreatedOnToolsVersion = 6.0;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1230;
 					};
 					F829C6B11A7A94F100A2CD59 = {
 						CreatedOnToolsVersion = 6.1.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1230;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -805,6 +822,7 @@
 				12C0B6FA219C0FA5000545C9 /* EFPointShape.swift in Sources */,
 				12EE9E2E23859A4B00241C60 /* BinaryFloatingPoint+.swift in Sources */,
 				12EE9E212385970A00241C60 /* CGColor+.swift in Sources */,
+				D2265577256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */,
 				12EE9E3C23863D6E00241C60 /* UIImage+.swift in Sources */,
 				12664ED11FA9CEDD00D56500 /* EFQRCode.swift in Sources */,
 				12EE9E502386968F00241C60 /* NSColor+.swift in Sources */,
@@ -814,6 +832,7 @@
 				12664EC81FA9CEDD00D56500 /* EFQRCodeRecognizer.swift in Sources */,
 				12664EB21FA9CED100D56500 /* CGImage+.swift in Sources */,
 				12C0B6FF219C0FD3000545C9 /* EFUIntPixel.swift in Sources */,
+				D2265506256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */,
 				12EE9E292385999A00241C60 /* CIColor+.swift in Sources */,
 				12C0B6F5219C0F7D000545C9 /* EFQRCodeMode.swift in Sources */,
 				12EE9E49238651F800241C60 /* UIColor+.swift in Sources */,
@@ -829,6 +848,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CF627141BA7CC240011A099 /* Tests.swift in Sources */,
+				D22654B8256E965300920D11 /* ObjCTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -840,6 +860,7 @@
 				12C0B6F9219C0FA5000545C9 /* EFPointShape.swift in Sources */,
 				12EE9E2D23859A4B00241C60 /* BinaryFloatingPoint+.swift in Sources */,
 				12EE9E202385970A00241C60 /* CGColor+.swift in Sources */,
+				D2265576256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */,
 				12EE9E3B23863D6E00241C60 /* UIImage+.swift in Sources */,
 				12664ED01FA9CEDD00D56500 /* EFQRCode.swift in Sources */,
 				12EE9E4F2386968F00241C60 /* NSColor+.swift in Sources */,
@@ -849,6 +870,7 @@
 				12664EC71FA9CEDD00D56500 /* EFQRCodeRecognizer.swift in Sources */,
 				12664EB11FA9CED100D56500 /* CGImage+.swift in Sources */,
 				12C0B6FE219C0FD3000545C9 /* EFUIntPixel.swift in Sources */,
+				D2265505256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */,
 				12EE9E282385999A00241C60 /* CIColor+.swift in Sources */,
 				12C0B6F4219C0F7D000545C9 /* EFQRCodeMode.swift in Sources */,
 				12EE9E48238651F800241C60 /* UIColor+.swift in Sources */,
@@ -867,6 +889,7 @@
 				12C0B6F6219C0F7D000545C9 /* EFQRCodeMode.swift in Sources */,
 				12EE9E2F23859A4B00241C60 /* BinaryFloatingPoint+.swift in Sources */,
 				5282BCBB1FF3903D00DFB36B /* EFQRCode.swift in Sources */,
+				D2265578256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */,
 				12EE9E3D23863D6E00241C60 /* UIImage+.swift in Sources */,
 				5282BCBD1FF3903D00DFB36B /* EFQRCodeGenerator.swift in Sources */,
 				12EE9E512386968F00241C60 /* NSColor+.swift in Sources */,
@@ -876,6 +899,7 @@
 				12EE9E242385973300241C60 /* EFQRCodeRecognizer.swift in Sources */,
 				12EE9E222385970A00241C60 /* CGColor+.swift in Sources */,
 				12C0B70A219C1046000545C9 /* EFInputCorrectionLevel.swift in Sources */,
+				D2265507256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */,
 				12EE9E2A2385999A00241C60 /* CIColor+.swift in Sources */,
 				12C0B700219C0FD3000545C9 /* EFUIntPixel.swift in Sources */,
 				12EE9E4A238651F800241C60 /* UIColor+.swift in Sources */,
@@ -894,6 +918,7 @@
 				12C0B6F8219C0FA5000545C9 /* EFPointShape.swift in Sources */,
 				12EE9E2C23859A4B00241C60 /* BinaryFloatingPoint+.swift in Sources */,
 				12EE9E1F2385970A00241C60 /* CGColor+.swift in Sources */,
+				D2265575256EA35600920D11 /* EFQRCode+ObjC.swift in Sources */,
 				12EE9E3A23863D6E00241C60 /* UIImage+.swift in Sources */,
 				12664ECF1FA9CEDD00D56500 /* EFQRCode.swift in Sources */,
 				12EE9E4E2386968F00241C60 /* NSColor+.swift in Sources */,
@@ -903,6 +928,7 @@
 				12664EC61FA9CEDD00D56500 /* EFQRCodeRecognizer.swift in Sources */,
 				12664EB01FA9CED100D56500 /* CGImage+.swift in Sources */,
 				12C0B6FD219C0FD3000545C9 /* EFUIntPixel.swift in Sources */,
+				D2265504256E9BFF00920D11 /* EFQRCode+Migration-v6.swift in Sources */,
 				12EE9E272385999A00241C60 /* CIColor+.swift in Sources */,
 				12C0B6F3219C0F7D000545C9 /* EFQRCodeMode.swift in Sources */,
 				12EE9E47238651F800241C60 /* UIColor+.swift in Sources */,
@@ -918,6 +944,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C256A531B096C770065714F /* Tests.swift in Sources */,
+				D22654B6256E965300920D11 /* ObjCTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -926,6 +953,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C256A541B096C770065714F /* Tests.swift in Sources */,
+				D22654B7256E965300920D11 /* ObjCTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/iOS/Localized.swift
+++ b/Examples/iOS/Localized.swift
@@ -25,6 +25,7 @@ enum Localized {
         static let allowTransparent = NSLocalizedString("Allow Transparent", comment: "Configuration prompt title")
         static let binarizationThreshold = NSLocalizedString("Binarization Threshold", comment: "Configuration prompt title")
         static let pointShape = NSLocalizedString("Point Shape", comment: "Configuration prompt title")
+        static let ignoreTiming = NSLocalizedString("Style Timing Pattern", comment: "Configuration prompt title")
     }
     static let success = NSLocalizedString("Success", comment: "Generic success alert title")
     static let error = NSLocalizedString("Error", comment: "Generic serious issue alert title")

--- a/Examples/iOS/watchOS Example Extension/ParametersInterfaceController.swift
+++ b/Examples/iOS/watchOS Example Extension/ParametersInterfaceController.swift
@@ -73,7 +73,16 @@ class ParametersInterfaceController: WKInterfaceController {
     }
     @IBAction func pickedMode(_ value: Int) {
         selectedMode = [.none, .grayscale, .binarization(threshold: 0.5)][value]
+        if case .binarization = selectedMode {
+            binarizationThresholdLabel.setHidden(false)
+            binarizationThresholdPicker?.setHidden(false)
+        } else {
+            binarizationThresholdLabel.setHidden(true)
+            binarizationThresholdPicker?.setHidden(true)
+        }
     }
+
+    @IBOutlet var binarizationThresholdLabel: WKInterfaceLabel!
     
     private var width = 1024
     @IBOutlet var widthButton: WKInterfaceButton?
@@ -153,7 +162,7 @@ class ParametersInterfaceController: WKInterfaceController {
     var icon: UIImage? = nil
     @IBOutlet var iconPicker: WKInterfacePicker? {
         didSet {
-            iconPicker?.setItems(Localized.Parameters.iconNames.map {
+            iconPicker?.setItems(([Localized.none] + Localized.Parameters.iconNames).map {
                 let item = WKPickerItem()
                 item.title = $0
                 return item
@@ -191,7 +200,7 @@ class ParametersInterfaceController: WKInterfaceController {
     var watermark: EFImage? = nil
     @IBOutlet var watermarkPicker: WKInterfacePicker? {
         didSet {
-            watermarkPicker?.setItems(Localized.Parameters.watermarkNames.map {
+            watermarkPicker?.setItems(([Localized.none] + Localized.Parameters.watermarkNames).map {
                 let item = WKPickerItem()
                 item.title = $0
                 return item
@@ -283,6 +292,11 @@ class ParametersInterfaceController: WKInterfaceController {
     @IBAction func pickedPointShape(_ value: Int) {
         pointShape = EFPointShape(rawValue: value) ?? pointShape
     }
+
+    private var ignoreTiming = false
+    @IBAction func ignoreTiming(_ value: Bool) {
+        ignoreTiming = value
+    }
     
     override func contextForSegue(withIdentifier segueIdentifier: String) -> Any? {
         ParametersInterfaceController.lastContent.value = link as NSString
@@ -301,6 +315,7 @@ class ParametersInterfaceController: WKInterfaceController {
         generator.setForegroundPointOffset(foregroundPointOffset: foregroundPointOffset)
         generator.setAllowTransparent(allowTransparent: allowsTransparent)
         generator.setPointShape(pointShape: pointShape)
+        generator.setIgnoreTiming(ignoreTiming: ignoreTiming)
         
         switch watermark {
         case .gif(let data)?: // GIF

--- a/Examples/iOS/watchOS Example/Base.lproj/Interface.storyboard
+++ b/Examples/iOS/watchOS Example/Base.lproj/Interface.storyboard
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="14490.70" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CRb-ZU-aKh">
-    <device id="watch38" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="17700" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CRb-ZU-aKh">
+    <device id="watch38"/>
     <dependencies>
         <deployment identifier="watchOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="14490.21"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="17500"/>
     </dependencies>
     <scenes>
         <!--NumberPad-->
@@ -219,12 +217,6 @@
                                 <action selector="changeInputCorrectionLevel:" destination="x7r-oY-9um" id="Q26-Vi-WCv"/>
                             </connections>
                         </slider>
-                        <label width="1" alignment="left" text="Mode" textAlignment="center" minimumScaleFactor="0.5" id="A9e-1b-MIh"/>
-                        <picker height="40" alignment="left" focusStyle="stack" id="a6K-zF-snE">
-                            <connections>
-                                <action selector="pickedMode:" destination="x7r-oY-9um" id="REW-xT-DS1"/>
-                            </connections>
-                        </picker>
                         <label width="1" alignment="left" text="Width &amp; Height" textAlignment="center" minimumScaleFactor="0.5" id="CJT-KQ-1aL"/>
                         <group width="1" alignment="left" id="S0W-4O-EuA">
                             <items>
@@ -309,28 +301,40 @@ Width &amp; Height</string>
                                 <action selector="pickedWatermarkMode:" destination="x7r-oY-9um" id="svk-PR-LoN"/>
                             </connections>
                         </picker>
-                        <label width="1" alignment="left" text="Foreground Point Offset" textAlignment="center" minimumScaleFactor="0.5" id="qcK-9t-ZZl"/>
-                        <picker height="40" alignment="left" focusStyle="stack" id="U0M-Ic-fIA">
-                            <connections>
-                                <action selector="pickedForegroundPointOffset:" destination="x7r-oY-9um" id="3N4-P5-tjZ"/>
-                            </connections>
-                        </picker>
                         <switch width="1" alignment="left" value="YES" title="Allow Transparent" numberOfLines="1" minimumScaleFactor="0.5" id="N9p-sO-zfZ">
                             <color key="tintColor" red="0.3803921569" green="0.81176470590000005" blue="0.78039215689999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
                                 <action selector="allowTransparent:" destination="x7r-oY-9um" id="Ye1-aq-yKY"/>
                             </connections>
                         </switch>
-                        <label width="1" alignment="left" text="Binarization Threshold" textAlignment="center" minimumScaleFactor="0.5" id="BcI-AJ-ri0"/>
-                        <picker height="40" alignment="left" focusStyle="stack" id="lmO-o0-84w">
+                        <label width="1" alignment="left" text="Point Offset" textAlignment="center" minimumScaleFactor="0.5" id="qcK-9t-ZZl"/>
+                        <picker height="40" alignment="left" focusStyle="stack" id="U0M-Ic-fIA">
                             <connections>
-                                <action selector="pickedBinarizationThreshold:" destination="x7r-oY-9um" id="zMm-2H-NTd"/>
+                                <action selector="pickedForegroundPointOffset:" destination="x7r-oY-9um" id="3N4-P5-tjZ"/>
                             </connections>
                         </picker>
                         <label width="1" alignment="left" text="Point Shape" textAlignment="center" id="3Y5-pz-aKM"/>
                         <picker height="40" alignment="left" focusStyle="stack" id="xtz-td-Dau">
                             <connections>
                                 <action selector="pickedPointShape:" destination="x7r-oY-9um" id="vfw-z9-TVU"/>
+                            </connections>
+                        </picker>
+                        <switch width="1" alignment="left" title="Style Timing Point" numberOfLines="1" minimumScaleFactor="0.5" id="odq-ce-Wgw">
+                            <color key="tintColor" red="0.3803921569" green="0.81176470590000005" blue="0.78039215689999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <connections>
+                                <action selector="ignoreTiming:" destination="x7r-oY-9um" id="xlC-Nd-Pm4"/>
+                            </connections>
+                        </switch>
+                        <label width="1" alignment="left" text="Mode" textAlignment="center" minimumScaleFactor="0.5" id="A9e-1b-MIh"/>
+                        <picker height="40" alignment="left" focusStyle="stack" id="a6K-zF-snE">
+                            <connections>
+                                <action selector="pickedMode:" destination="x7r-oY-9um" id="REW-xT-DS1"/>
+                            </connections>
+                        </picker>
+                        <label width="1" alignment="left" hidden="YES" text="Binarization Threshold" textAlignment="center" minimumScaleFactor="0.5" id="BcI-AJ-ri0"/>
+                        <picker height="40" alignment="left" hidden="YES" focusStyle="stack" id="lmO-o0-84w">
+                            <connections>
+                                <action selector="pickedBinarizationThreshold:" destination="x7r-oY-9um" id="zMm-2H-NTd"/>
                             </connections>
                         </picker>
                         <button width="1" alignment="left" title="Generate" id="UDk-vC-rXj">
@@ -342,7 +346,8 @@ Width &amp; Height</string>
                     </items>
                     <connections>
                         <outlet property="backgroundColorPicker" destination="7Px-Vg-gTE" id="mG3-mf-mHG"/>
-                        <outlet property="binarizationThresholdPicker" destination="lmO-o0-84w" id="Kz5-ea-YzO"/>
+                        <outlet property="binarizationThresholdLabel" destination="BcI-AJ-ri0" id="Tmb-cx-K0c"/>
+                        <outlet property="binarizationThresholdPicker" destination="lmO-o0-84w" id="FrP-o2-Dje"/>
                         <outlet property="contentDisplay" destination="pSv-yw-I6b" id="RVw-tK-to0"/>
                         <outlet property="foregroundColorPicker" destination="LB4-rc-W90" id="r7v-dV-pMY"/>
                         <outlet property="foregroundPointOffsetPicker" destination="U0M-Ic-fIA" id="eD3-DU-lgl"/>

--- a/Examples/macOS/macOS Example/ViewController+Recognizer.swift
+++ b/Examples/macOS/macOS Example/ViewController+Recognizer.swift
@@ -96,6 +96,7 @@ extension ViewController {
         recognizerViewResult.layer?.borderWidth = 1
         recognizerViewResult.layer?.cornerRadius = 5
         recognizerView.addSubview(recognizerViewResult)
+        recognizerViewResult.setContentHuggingPriority(.defaultLow, for: .vertical)
         recognizerViewResult.snp.makeConstraints {
             (make) in
             make.top.equalTo(10)
@@ -123,7 +124,7 @@ extension ViewController {
     }
 
     /// https://gist.github.com/jlindsey/499215
-    func selectImageFromDisk(process: @escaping (EFImage) -> Void) {
+    func selectImageFromDisk(process: @escaping (EFImage?) -> Void) {
         let panel = NSOpenPanel()
         panel.allowedFileTypes = NSImage.imageTypes
         panel.allowsMultipleSelection = false
@@ -138,17 +139,20 @@ extension ViewController {
             [weak self] (result) in
             guard self != nil else { return }
             guard result.rawValue == NSFileHandlingPanelOKButton else {
-                return panel.close()
+                panel.close()
+                return process(nil)
             }
             // We aren't allowing multiple selection,
             // but NSOpenPanel still returns an array with a single element.
-            guard let imagePath = panel.urls.first else { return }
+            guard let imagePath = panel.urls.first else {
+                return process(nil)
+            }
             if imagePath.absoluteString.lowercased().hasSuffix(".gif"),
-                let image = try? Data(contentsOf: imagePath) {
+               let image = try? Data(contentsOf: imagePath) {
                 return process(.gif(image))
             }
             if let image = NSImage(contentsOf: imagePath) {
-                process(.normal(image))
+                return process(.normal(image))
             }
         }
     }

--- a/Examples/macOS/macOS Example/ViewController.swift
+++ b/Examples/macOS/macOS Example/ViewController.swift
@@ -76,6 +76,7 @@ class ViewController: NSViewController {
     var allowTransparent = true
     var binarizationThreshold: CGFloat = 0.5
     var pointShape: EFPointShape = .square
+    var ignoreTiming = false
 
     let titleArray = [
         Localized.Title.inputCorrectionLevel,
@@ -91,7 +92,8 @@ class ViewController: NSViewController {
         Localized.Title.foregroundPointOffset,
         Localized.Title.allowTransparent,
         Localized.Title.binarizationThreshold,
-        Localized.Title.pointShape
+        Localized.Title.pointShape,
+        Localized.Title.ignoreTiming,
     ]
 
     override func viewDidLoad() {
@@ -121,8 +123,8 @@ class ViewController: NSViewController {
         backgroundView.snp.makeConstraints {
             (make) in
             make.top.leading.trailing.bottom.equalTo(0)
-            make.width.equalTo(800)
-            make.height.equalTo(380)
+            make.width.equalTo(840)
+            make.height.equalTo(440)
         }
 
         backgroundView.addSubview(leftBarView)

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -44,6 +44,16 @@ let package = Package(
                 ],
                 path: "Source",
                 exclude: ["Info.plist", "Info-tvOS.plist"]),
+        .testTarget(name: "EFQRCodeSwiftTests",
+                    dependencies: ["EFQRCode"],
+                    path: "Tests",
+                    exclude: ["Info.plist", "ObjCTests.m"],
+                    resources: [.process("Resources")]),
+        .testTarget(name: "EFQRCodeObjCTests",
+                    dependencies: ["EFQRCode"],
+                    path: "Tests",
+                    exclude: ["Info.plist", "Tests.swift"],
+                    resources: [.process("Resources")]),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Source/CGColor+.swift
+++ b/Source/CGColor+.swift
@@ -71,12 +71,11 @@ extension CGColor {
 }
 
 public extension CGColor {
-    static func white(white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> CGColor? {
+    static func white(_ white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> CGColor? {
         return initWith(red: white, green: white, blue: white, alpha: alpha)
     }
     
-    static func black(black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> CGColor? {
-        let white: CGFloat = 1.0 - black
-        return initWith(red: white, green: white, blue: white, alpha: alpha)
+    static func black(_ black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> CGColor? {
+        return white(1.0 - black, alpha: alpha)
     }
 }

--- a/Source/CIColor+.swift
+++ b/Source/CIColor+.swift
@@ -32,7 +32,6 @@ import UIKit
 #endif
 
 extension CIColor {
-
     #if canImport(UIKit)
     func uiColor() -> UIColor {
         return UIColor(ciColor: self)

--- a/Source/EFIntSize.swift
+++ b/Source/EFIntSize.swift
@@ -26,23 +26,19 @@
 
 import CoreGraphics
 
-#if canImport(CoreImage)
-import CoreImage
-#endif
-
 @objcMembers
-public class EFIntSize: NSObject {
-    public private(set) var width: Int = 0
-    public private(set) var height: Int = 0
-
-    public init(width: Int, height: Int) {
+public final class EFIntSize: NSObject {
+    public let width: Int
+    public let height: Int
+    
+    public init(width: Int = 0, height: Int = 0) {
         self.width = width
         self.height = height
     }
     
-    public init(size: CGSize) {
-        self.width = Int(size.width)
-        self.height = Int(size.height)
+    public convenience init(size: CGSize) {
+        self.init(width: Int(size.width),
+                  height: Int(size.height))
     }
 
     public var cgSize: CGSize {

--- a/Source/EFPointShape.swift
+++ b/Source/EFPointShape.swift
@@ -24,12 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import CoreGraphics
 import Foundation
-
-#if canImport(CoreImage)
-import CoreImage
-#endif
 
 @objc public enum EFPointShape: Int {
     case square         = 0

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -47,7 +47,7 @@ extension EFQRCode {
     }
 
     public static func generateGIF(using generator: EFQRCodeGenerator,
-                                   withIntputGIF data: Data,
+                                   withWatermarkGIF data: Data,
                                    savingTo pathToSave: URL? = nil,
                                    delay: Double? = nil, loopCount: Int? = nil,
                                    useMultipleThreads:Bool = false) -> Data? {

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -39,7 +39,7 @@ extension EFQRCode {
 
     private static func batchWatermark(frames: inout [CGImage], generator: EFQRCodeGenerator, start: Int, end: Int) {
         for index in start ... end {
-            generator.withWatermark(frames[index])
+            generator.watermark = frames[index]
             if let frameWithCode = generator.generate() {
                 frames[index] = frameWithCode
             }
@@ -108,7 +108,7 @@ extension EFQRCode {
             } else {
                 // Clear watermark
                 for (index, frame) in frames.enumerated() {
-                    generator.withWatermark(frame)
+                    generator.watermark = frame
                     if let frameWithCode = generator.generate() {
                         frames[index] = frameWithCode
                     }

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -34,20 +34,25 @@ import MobileCoreServices
 import CoreServices
 #endif
 
-public extension EFQRCode {
+extension EFQRCode {
 
     private static let framesPerSecond = 24
 
     private static func batchWatermark(frames: inout [CGImage], generator: EFQRCodeGenerator, start: Int, end: Int) {
         for index in start ... end {
-            generator.setWatermark(watermark: frames[index])
+            generator.withWatermark(frames[index])
             if let frameWithCode = generator.generate() {
                 frames[index] = frameWithCode
             }
         }
     }
-    
-    static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
+
+    @available(*, deprecated, renamed: "generateGIF(withData:using:savingTo:delay:loopCount:useMultipleThreads:)")
+    public static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
+        generateGIF(withData: data, using: generator, savingTo: pathToSave, delay: delay, loopCount: loopCount, useMultipleThreads: useMultipleThread)
+    }
+
+    public static func generateGIF(withData data: Data, using generator: EFQRCodeGenerator, savingTo pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThreads:Bool = false) -> Data? {
         if let source = CGImageSourceCreateWithData(data as CFData, nil) {
             var frames = source.toCGImages()
 
@@ -78,7 +83,7 @@ public extension EFQRCode {
                 fileProperties = tempDict as CFDictionary
             }
 
-            if useMultipleThread {
+            if useMultipleThreads {
                 let group = DispatchGroup()
 
                 let threshold = frames.count / framesPerSecond
@@ -105,7 +110,7 @@ public extension EFQRCode {
             } else {
                 // Clear watermark
                 for (index, frame) in frames.enumerated() {
-                    generator.setWatermark(watermark: frame)
+                    generator.withWatermark(frame)
                     if let frameWithCode = generator.generate() {
                         frames[index] = frameWithCode
                     }

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -35,7 +35,6 @@ import CoreServices
 #endif
 
 extension EFQRCode {
-
     private static let framesPerSecond = 24
 
     private static func batchWatermark(frames: inout [CGImage], generator: EFQRCodeGenerator, start: Int, end: Int) {
@@ -47,12 +46,11 @@ extension EFQRCode {
         }
     }
 
-    @available(*, deprecated, renamed: "generateGIF(withData:using:savingTo:delay:loopCount:useMultipleThreads:)")
-    public static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
-        generateGIF(withData: data, using: generator, savingTo: pathToSave, delay: delay, loopCount: loopCount, useMultipleThreads: useMultipleThread)
-    }
-
-    public static func generateGIF(withData data: Data, using generator: EFQRCodeGenerator, savingTo pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThreads:Bool = false) -> Data? {
+    public static func generateGIF(using generator: EFQRCodeGenerator,
+                                   withWatermark data: Data,
+                                   savingTo pathToSave: URL? = nil,
+                                   delay: Double? = nil, loopCount: Int? = nil,
+                                   useMultipleThreads:Bool = false) -> Data? {
         if let source = CGImageSourceCreateWithData(data as CFData, nil) {
             var frames = source.toCGImages()
 
@@ -126,7 +124,6 @@ extension EFQRCode {
 }
 
 extension CGImageSource {
-
     // GIF
     func toCGImages() -> [CGImage] {
         let gifCount = CGImageSourceGetCount(self)
@@ -138,7 +135,6 @@ extension CGImageSource {
 }
 
 extension Array where Element: CGImage {
-
     func toGifData(framePropertiesArray: [CFDictionary], fileProperties: CFDictionary) -> Data? {
         guard let mutableData = CFDataCreateMutable(nil, 0) else { return nil }
         guard let destination = CGImageDestinationCreateWithData(mutableData, kUTTypeGIF, count, nil) else { return nil }

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -48,7 +48,6 @@ extension EFQRCode {
 
     public static func generateGIF(using generator: EFQRCodeGenerator,
                                    withWatermarkGIF data: Data,
-                                   savingTo pathToSave: URL? = nil,
                                    delay: Double? = nil, loopCount: Int? = nil,
                                    useMultipleThreads:Bool = false) -> Data? {
         if let source = CGImageSourceCreateWithData(data as CFData, nil) {

--- a/Source/EFQRCode+GIF.swift
+++ b/Source/EFQRCode+GIF.swift
@@ -47,7 +47,7 @@ extension EFQRCode {
     }
 
     public static func generateGIF(using generator: EFQRCodeGenerator,
-                                   withWatermark data: Data,
+                                   withIntputGIF data: Data,
                                    savingTo pathToSave: URL? = nil,
                                    delay: Double? = nil, loopCount: Int? = nil,
                                    useMultipleThreads:Bool = false) -> Data? {

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -73,9 +73,9 @@ extension EFQRCode {
         )
     }
 
-    @available(*, deprecated, renamed: "generateGIF(withWatermark:using:savingTo:delay:loopCount:useMultipleThreads:)")
+    @available(*, deprecated, renamed: "generateGIF(withIntputGIF:using:savingTo:delay:loopCount:useMultipleThreads:)")
     public static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
-        return generateGIF(using: generator, withWatermark: data,
+        return generateGIF(using: generator, withIntputGIF: data,
                            savingTo: pathToSave,
                            delay: delay, loopCount: loopCount,
                            useMultipleThreads: useMultipleThread)

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -74,10 +74,9 @@ extension EFQRCode {
     public static func generateWithGIF(
         data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil,
         delay: Double? = nil, loopCount: Int? = nil,
-        useMultipleThread:Bool = false
+        useMultipleThread: Bool = false
     ) -> Data? {
         return generateGIF(using: generator, withWatermarkGIF: data,
-                           savingTo: pathToSave,
                            delay: delay, loopCount: loopCount,
                            useMultipleThreads: useMultipleThread)
     }

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -21,7 +21,7 @@ extension EFQRCode {
     #endif
 
 
-    @available(*, deprecated, renamed: "generate(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    @available(*, deprecated, renamed: "generate(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:pointOffset:)")
     public static func generate(
         content: String,
         contentEncoding: String.Encoding = .utf8,
@@ -39,10 +39,18 @@ extension EFQRCode {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
         ) -> CGImage? {
-        return generate(for: content, encoding: contentEncoding, size: size, backgroundColor: backgroundColor, foregroundColor: foregroundColor, watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent, inputCorrectionLevel: inputCorrectionLevel, icon: icon, iconSize: iconSize, pointShape: pointShape, mode: mode, magnification: magnification, foregroundPointOffset: foregroundPointOffset)
+        return generate(
+            for: content, encoding: contentEncoding, size: size,
+            backgroundColor: backgroundColor, foregroundColor: foregroundColor,
+            watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
+            inputCorrectionLevel: inputCorrectionLevel,
+            icon: icon, iconSize: iconSize,
+            pointShape: pointShape, pointOffset: foregroundPointOffset,
+            mode: mode, magnification: magnification
+        )
     }
     
-    @available(*, deprecated, renamed: "generateGIF(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    @available(*, deprecated, renamed: "generateGIF(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:pointOffset:)")
     public static func generateWithGIF(
         content: String,
         contentEncoding: String.Encoding = .utf8,
@@ -67,9 +75,8 @@ extension EFQRCode {
             watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
             inputCorrectionLevel: inputCorrectionLevel,
             icon: icon, iconSize: iconSize,
-            pointShape: pointShape,
-            mode: mode, magnification: magnification,
-            foregroundPointOffset: foregroundPointOffset
+            pointShape: pointShape, pointOffset: foregroundPointOffset,
+            mode: mode, magnification: magnification
         )
     }
 
@@ -127,9 +134,9 @@ extension EFQRCodeGenerator {
     public func setWatermark(watermark: CGImage?, mode: EFWatermarkMode? = nil) {
         withWatermark(watermark, mode: mode)
     }
-    @available(*, deprecated, renamed: "withForegroundPointOffset(_:)")
+    @available(*, deprecated, renamed: "withPointOffset(_:)")
     public func setForegroundPointOffset(foregroundPointOffset: CGFloat) {
-        withForegroundPointOffset(foregroundPointOffset)
+        withPointOffset(foregroundPointOffset)
     }
     @available(*, deprecated, renamed: "withTransparentWatermark(_:)")
     public func setAllowTransparent(allowTransparent: Bool) {

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -146,9 +146,9 @@ extension EFQRCodeGenerator {
     public func setPointShape(pointShape: EFPointShape) {
         withPointShape(pointShape)
     }
-    @available(*, deprecated, renamed: "withoutStaticTiming(_:)")
-    public func setIgnoreTiming(ignoreTiming: Bool) {
-        withoutStaticTiming(!ignoreTiming)
+    @available(*, deprecated, renamed: "withStyledTimingPoint(_:)")
+    public func setIgnoreTiming(ignoreTiming isTimingStyled: Bool) {
+        withStyledTimingPoint(isTimingStyled)
     }
 }
 

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -1,0 +1,175 @@
+//
+//  EFQRCode+Migration-v6.swift
+//  EFQRCode
+//
+//  Created by Apollo Zhu on 11/25/20.
+//  Copyright © 2020 EyreFree. All rights reserved.
+//
+
+#if canImport(CoreImage)
+import CoreImage
+#endif
+import CoreGraphics
+import Foundation
+
+extension EFQRCode {
+    #if canImport(CoreImage)
+    @available(*, deprecated, renamed: "recognize(_:)")
+    public static func recognize(image: CGImage) -> [String]? {
+        return recognize(image)
+    }
+    #endif
+
+
+    @available(*, deprecated, renamed: "generate(_:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    public static func generate(
+        content: String,
+        contentEncoding: String.Encoding = .utf8,
+        size: EFIntSize = EFIntSize(width: 600, height: 600),
+        backgroundColor: CGColor = CGColor.white()!,
+        foregroundColor: CGColor = CGColor.black()!,
+        watermark: CGImage? = nil,
+        watermarkMode: EFWatermarkMode = .scaleAspectFill,
+        inputCorrectionLevel: EFInputCorrectionLevel = .h,
+        icon: CGImage? = nil,
+        iconSize: EFIntSize? = nil,
+        allowTransparent: Bool = true,
+        pointShape: EFPointShape = .square,
+        mode: EFQRCodeMode = .none,
+        magnification: EFIntSize? = nil,
+        foregroundPointOffset: CGFloat = 0
+        ) -> CGImage? {
+        return generate(content, encoding: contentEncoding, size: size, backgroundColor: backgroundColor, foregroundColor: foregroundColor, watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent, inputCorrectionLevel: inputCorrectionLevel, icon: icon, iconSize: iconSize, pointShape: pointShape, mode: mode, magnification: magnification, foregroundPointOffset: foregroundPointOffset)
+    }
+    
+    @available(*, deprecated, renamed: "generateGIF(_:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    public static func generateWithGIF(
+        content: String,
+        contentEncoding: String.Encoding = .utf8,
+        size: EFIntSize = EFIntSize(width: 600, height: 600),
+        backgroundColor: CGColor = CGColor.white()!,
+        foregroundColor: CGColor = CGColor.black()!,
+        watermark: Data,
+        watermarkMode: EFWatermarkMode = .scaleAspectFill,
+        inputCorrectionLevel: EFInputCorrectionLevel = .h,
+        icon: CGImage? = nil,
+        iconSize: EFIntSize? = nil,
+        allowTransparent: Bool = true,
+        pointShape: EFPointShape = .square,
+        mode: EFQRCodeMode = .none,
+        magnification: EFIntSize? = nil,
+        foregroundPointOffset: CGFloat = 0
+    ) -> Data? {
+        return generateGIF(
+            content, encoding: contentEncoding,
+            size: size,
+            backgroundColor: backgroundColor, foregroundColor: foregroundColor,
+            watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
+            inputCorrectionLevel: inputCorrectionLevel,
+            icon: icon, iconSize: iconSize,
+            pointShape: pointShape,
+            mode: mode, magnification: magnification,
+            foregroundPointOffset: foregroundPointOffset
+        )
+    }
+
+    @available(*, deprecated, renamed: "generateGIF(withWatermark:using:savingTo:delay:loopCount:useMultipleThreads:)")
+    public static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
+        return generateGIF(using: generator, withWatermark: data,
+                           savingTo: pathToSave,
+                           delay: delay, loopCount: loopCount,
+                           useMultipleThreads: useMultipleThread)
+    }
+}
+
+extension EFQRCodeGenerator {
+    @available(*, deprecated, renamed: "withContent(_:)")
+    public func setContent(content: String) {
+        withContent(content)
+    }
+    @available(*, deprecated, renamed: "withContentEncoding(_:)")
+    public func setContentEncoding(encoding: String.Encoding) {
+        withContentEncoding(encoding)
+    }
+    @available(*, deprecated, renamed: "withMode(_:)")
+    public func setMode(mode: EFQRCodeMode) {
+        withMode(mode)
+    }
+    @available(*, deprecated, renamed: "withInputCorrectionLevel(_:)")
+    public func setInputCorrectionLevel(inputCorrectionLevel: EFInputCorrectionLevel) {
+        withInputCorrectionLevel(inputCorrectionLevel)
+    }
+    @available(*, deprecated, renamed: "withSize(_:)")
+    public func setSize(size: EFIntSize) {
+        withSize(size)
+    }
+    @available(*, deprecated, renamed: "withMagnification(_:)")
+    public func setMagnification(magnification: EFIntSize?) {
+        withMagnification(magnification)
+    }
+    #if canImport(CoreImage)
+    @nonobjc
+    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
+    public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
+        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
+    }
+    #endif
+    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
+    public func setColors(backgroundColor: CGColor, foregroundColor: CGColor) {
+        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
+    }
+    @available(*, deprecated, renamed: "withIcon(_:size:)")
+    public func setIcon(icon: CGImage?, size: EFIntSize?) {
+        self.icon = icon
+        self.iconSize = size
+    }
+    @available(*, deprecated, renamed: "withWatermark(_:mode:)")
+    public func setWatermark(watermark: CGImage?, mode: EFWatermarkMode? = nil) {
+        withWatermark(watermark, mode: mode)
+    }
+    @available(*, deprecated, renamed: "withForegroundPointOffset(_:)")
+    public func setForegroundPointOffset(foregroundPointOffset: CGFloat) {
+        withForegroundPointOffset(foregroundPointOffset)
+    }
+    @available(*, deprecated, renamed: "withTransparentWatermark(_:)")
+    public func setAllowTransparent(allowTransparent: Bool) {
+        withTransparentWatermark(allowTransparent)
+    }
+    @available(*, deprecated, renamed: "withPointShape(_:)")
+    public func setPointShape(pointShape: EFPointShape) {
+        withPointShape(pointShape)
+    }
+    @available(*, deprecated, renamed: "withoutStaticTiming(_:)")
+    public func setIgnoreTiming(ignoreTiming: Bool) {
+        withoutStaticTiming(!ignoreTiming)
+    }
+
+    @available(*, deprecated, renamed: "init(_:size:)")
+    public convenience init(
+        content: String,
+        size: EFIntSize = EFIntSize(width: 256, height: 256)
+    ) {
+        self.init(content, size: size)
+    }
+}
+
+#if canImport(CoreImage)
+extension EFQRCodeRecognizer {
+    @available(*, deprecated, message: "Set `image` property directly.")
+    public func setImage(image: CGImage?) {
+        self.image = image
+    }
+}
+#endif
+
+extension CGColor {
+    @available(*, deprecated, renamed: "white(_:alpha:)")
+    static func white(white: CGFloat, alpha: CGFloat = 1.0) -> CGColor? {
+        return CGColor.white(white, alpha: alpha)
+    }
+
+    @available(*, deprecated, renamed: "black(_:alpha:)")
+    static func black(black: CGFloat, alpha: CGFloat = 1.0) -> CGColor? {
+        return CGColor.black(black, alpha: alpha)
+    }
+}

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -21,7 +21,7 @@ extension EFQRCode {
     #endif
 
 
-    @available(*, deprecated, renamed: "generate(_:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    @available(*, deprecated, renamed: "generate(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
     public static func generate(
         content: String,
         contentEncoding: String.Encoding = .utf8,
@@ -39,10 +39,10 @@ extension EFQRCode {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
         ) -> CGImage? {
-        return generate(content, encoding: contentEncoding, size: size, backgroundColor: backgroundColor, foregroundColor: foregroundColor, watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent, inputCorrectionLevel: inputCorrectionLevel, icon: icon, iconSize: iconSize, pointShape: pointShape, mode: mode, magnification: magnification, foregroundPointOffset: foregroundPointOffset)
+        return generate(for: content, encoding: contentEncoding, size: size, backgroundColor: backgroundColor, foregroundColor: foregroundColor, watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent, inputCorrectionLevel: inputCorrectionLevel, icon: icon, iconSize: iconSize, pointShape: pointShape, mode: mode, magnification: magnification, foregroundPointOffset: foregroundPointOffset)
     }
     
-    @available(*, deprecated, renamed: "generateGIF(_:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
+    @available(*, deprecated, renamed: "generateGIF(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
     public static func generateWithGIF(
         content: String,
         contentEncoding: String.Encoding = .utf8,
@@ -61,7 +61,7 @@ extension EFQRCode {
         foregroundPointOffset: CGFloat = 0
     ) -> Data? {
         return generateGIF(
-            content, encoding: contentEncoding,
+            for: content, encoding: contentEncoding,
             size: size,
             backgroundColor: backgroundColor, foregroundColor: foregroundColor,
             watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
@@ -142,14 +142,6 @@ extension EFQRCodeGenerator {
     @available(*, deprecated, renamed: "withoutStaticTiming(_:)")
     public func setIgnoreTiming(ignoreTiming: Bool) {
         withoutStaticTiming(!ignoreTiming)
-    }
-
-    @available(*, deprecated, renamed: "init(_:size:)")
-    public convenience init(
-        content: String,
-        size: EFIntSize = EFIntSize(width: 256, height: 256)
-    ) {
-        self.init(content, size: size)
     }
 }
 

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -70,13 +70,13 @@ extension EFQRCode {
         )
     }
 
-    @available(*, deprecated, renamed: "generateGIF(withIntputGIF:using:savingTo:delay:loopCount:useMultipleThreads:)")
+    @available(*, deprecated, renamed: "generateGIF(withWatermarkGIF:using:savingTo:delay:loopCount:useMultipleThreads:)")
     public static func generateWithGIF(
         data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil,
         delay: Double? = nil, loopCount: Int? = nil,
         useMultipleThread:Bool = false
     ) -> Data? {
-        return generateGIF(using: generator, withIntputGIF: data,
+        return generateGIF(using: generator, withWatermarkGIF: data,
                            savingTo: pathToSave,
                            delay: delay, loopCount: loopCount,
                            useMultipleThreads: useMultipleThread)

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -71,7 +71,11 @@ extension EFQRCode {
     }
 
     @available(*, deprecated, renamed: "generateGIF(withIntputGIF:using:savingTo:delay:loopCount:useMultipleThreads:)")
-    public static func generateWithGIF(data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil, delay: Double? = nil, loopCount: Int? = nil, useMultipleThread:Bool = false) -> Data? {
+    public static func generateWithGIF(
+        data: Data, generator: EFQRCodeGenerator, pathToSave: URL? = nil,
+        delay: Double? = nil, loopCount: Int? = nil,
+        useMultipleThread:Bool = false
+    ) -> Data? {
         return generateGIF(using: generator, withIntputGIF: data,
                            savingTo: pathToSave,
                            delay: delay, loopCount: loopCount,
@@ -132,6 +136,15 @@ extension EFQRCodeGenerator {
     @available(*, deprecated, renamed: "withStyledTimingPoint(_:)")
     public func setIgnoreTiming(ignoreTiming isTimingStyled: Bool) {
         withStyledTimingPoint(isTimingStyled)
+    }
+
+    @available(*, deprecated, renamed: "minMagnification(greaterThanOrEqualTo:)")
+    public func minMagnificationGreaterThanOrEqualTo(size: CGFloat) -> Int? {
+        return minMagnification(greaterThanOrEqualTo: size)
+    }
+    @available(*, deprecated, renamed: "maxMagnification(lessThanOrEqualTo:)")
+    public func maxMagnificationLessThanOrEqualTo(size: CGFloat) -> Int? {
+        return maxMagnification(lessThanOrEqualTo: size)
     }
 }
 

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -160,7 +160,7 @@ extension EFQRCode {
 
 extension EFQRCodeRecognizer {
     @available(*, deprecated, message: "Set `image` property directly.")
-    public func setImage(image: CGImage?) {
+    public func setImage(image: CGImage) {
         self.image = image
     }
 }

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -153,7 +153,8 @@ import CoreImage
 
 extension EFQRCode {
     @available(*, deprecated, renamed: "recognize(_:)")
-    public static func recognize(image: CGImage) -> [String]? {
+    public static func recognize(image: CGImage?) -> [String]? {
+        guard let image = image else { return nil }
         return recognize(image)
     }
 }

--- a/Source/EFQRCode+Migration-v6.swift
+++ b/Source/EFQRCode+Migration-v6.swift
@@ -6,21 +6,10 @@
 //  Copyright © 2020 EyreFree. All rights reserved.
 //
 
-#if canImport(CoreImage)
-import CoreImage
-#endif
 import CoreGraphics
 import Foundation
 
 extension EFQRCode {
-    #if canImport(CoreImage)
-    @available(*, deprecated, renamed: "recognize(_:)")
-    public static func recognize(image: CGImage) -> [String]? {
-        return recognize(image)
-    }
-    #endif
-
-
     @available(*, deprecated, renamed: "generate(for:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:pointOffset:)")
     public static func generate(
         content: String,
@@ -38,15 +27,16 @@ extension EFQRCode {
         mode: EFQRCodeMode = .none,
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
-        ) -> CGImage? {
+    ) -> CGImage? {
         return generate(
-            for: content, encoding: contentEncoding, size: size,
+            for: content, encoding: contentEncoding,
+            inputCorrectionLevel: inputCorrectionLevel,
+            size: size, magnification: magnification,
             backgroundColor: backgroundColor, foregroundColor: foregroundColor,
             watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
-            inputCorrectionLevel: inputCorrectionLevel,
             icon: icon, iconSize: iconSize,
             pointShape: pointShape, pointOffset: foregroundPointOffset,
-            mode: mode, magnification: magnification
+            mode: mode
         )
     }
     
@@ -70,13 +60,13 @@ extension EFQRCode {
     ) -> Data? {
         return generateGIF(
             for: content, encoding: contentEncoding,
-            size: size,
+            inputCorrectionLevel: inputCorrectionLevel,
+            size: size, magnification: magnification,
             backgroundColor: backgroundColor, foregroundColor: foregroundColor,
             watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
-            inputCorrectionLevel: inputCorrectionLevel,
             icon: icon, iconSize: iconSize,
             pointShape: pointShape, pointOffset: foregroundPointOffset,
-            mode: mode, magnification: magnification
+            mode: mode
         )
     }
 
@@ -114,13 +104,6 @@ extension EFQRCodeGenerator {
     public func setMagnification(magnification: EFIntSize?) {
         withMagnification(magnification)
     }
-    #if canImport(CoreImage)
-    @nonobjc
-    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
-    public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
-        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
-    }
-    #endif
     @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
     public func setColors(backgroundColor: CGColor, foregroundColor: CGColor) {
         withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
@@ -153,10 +136,27 @@ extension EFQRCodeGenerator {
 }
 
 #if canImport(CoreImage)
+import CoreImage
+
+extension EFQRCode {
+    @available(*, deprecated, renamed: "recognize(_:)")
+    public static func recognize(image: CGImage) -> [String]? {
+        return recognize(image)
+    }
+}
+
 extension EFQRCodeRecognizer {
     @available(*, deprecated, message: "Set `image` property directly.")
     public func setImage(image: CGImage?) {
         self.image = image
+    }
+}
+
+extension EFQRCodeGenerator {
+    @nonobjc
+    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
+    public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
+        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
     }
 }
 #endif

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -53,7 +53,7 @@ extension EFQRCodeGenerator {
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIFWithWatermark(_ data: Data, savingTo pathToSave: URL?, delay: Double?, loopCount: Int?, useMultipleThreads: Bool) -> Data? {
+    public func generateGIFWithWatermark(_ data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
         return EFQRCode.generateGIF(
             using: self, withWatermark: data, savingTo: pathToSave,
             delay: delay, loopCount: loopCount,

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -1,0 +1,63 @@
+//
+//  EFQRCode+ObjC.swift
+//  EFQRCode
+//
+//  Created by Apollo Zhu on 11/25/20.
+//  Copyright © 2020 EyreFree. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+extension EFQRCodeGenerator {
+    @available(swift, deprecated: 1.0)
+    public convenience init(
+        content: String,
+        encoding: UInt = String.Encoding.utf8.rawValue,
+        size: EFIntSize = EFIntSize(width: 256, height: 256)
+    ) {
+        self.init(content, encoding: String.Encoding(rawValue: encoding), size: size)
+    }
+
+    @discardableResult
+    @available(swift, deprecated: 1.0)
+    public func withContent(_ content: String, encoding: UInt) -> EFQRCodeGenerator {
+        return withContent(content, encoding: String.Encoding(rawValue: encoding))
+    }
+
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withNormalMode() -> EFQRCodeGenerator {
+        return withMode(nil)
+    }
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withGrayscaleMode() -> EFQRCodeGenerator {
+        return withMode(.grayscale)
+    }
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withBinarizationMode(threshold: CGFloat) -> EFQRCodeGenerator {
+        return withMode(.binarization(threshold: threshold))
+    }
+
+    @discardableResult
+    @available(swift, obsoleted: 1.0)
+    public func withWatermark(_ watermark: CGImage, mode: EFWatermarkMode) -> EFQRCodeGenerator {
+        return withWatermark(watermark, mode: mode)
+    }
+
+    @available(swift, obsoleted: 1.0)
+    public func generateGIFWithWatermark(_ data: Data) -> Data? {
+        return EFQRCode.generateGIF(using: self, withWatermark: data)
+    }
+
+    @available(swift, obsoleted: 1.0)
+    public func generateGIFWithWatermark(_ data: Data, savingTo pathToSave: URL?, delay: Double?, loopCount: Int?, useMultipleThreads: Bool) -> Data? {
+        return EFQRCode.generateGIF(
+            using: self, withWatermark: data, savingTo: pathToSave,
+            delay: delay, loopCount: loopCount,
+            useMultipleThreads: useMultipleThreads
+        )
+    }
+}

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -11,12 +11,9 @@ import Foundation
 
 extension EFQRCodeGenerator {
     @available(swift, deprecated: 1.0)
-    public convenience init(
-        content: String,
-        encoding: UInt = String.Encoding.utf8.rawValue,
-        size: EFIntSize = EFIntSize(width: 256, height: 256)
-    ) {
-        self.init(content, encoding: String.Encoding(rawValue: encoding), size: size)
+    public convenience init(content: String, encoding: UInt, size: EFIntSize) {
+        let encoding = String.Encoding(rawValue: encoding)
+        self.init(content: content, encoding: encoding, size: size)
     }
 
     @discardableResult

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -45,12 +45,12 @@ extension EFQRCodeGenerator {
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIF(inputGIF data: Data) -> Data? {
+    public func generateGIF(watermarkGIF data: Data) -> Data? {
         return EFQRCode.generateGIF(using: self, withWatermarkGIF: data)
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIF(inputGIF data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
+    public func generateGIF(watermarkGIF data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
         return EFQRCode.generateGIF(
             using: self, withWatermarkGIF: data, savingTo: pathToSave,
             delay: delay, loopCount: loopCount,

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -10,14 +10,14 @@ import CoreGraphics
 import Foundation
 
 extension EFQRCodeGenerator {
-    @available(swift, deprecated: 1.0)
+    @available(swift, obsoleted: 1.0)
     public convenience init(content: String, encoding: UInt, size: EFIntSize) {
         let encoding = String.Encoding(rawValue: encoding)
         self.init(content: content, encoding: encoding, size: size)
     }
 
     @discardableResult
-    @available(swift, deprecated: 1.0)
+    @available(swift, obsoleted: 1.0)
     public func withContent(_ content: String, encoding: UInt) -> EFQRCodeGenerator {
         return withContent(content, encoding: String.Encoding(rawValue: encoding))
     }

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -46,13 +46,13 @@ extension EFQRCodeGenerator {
 
     @available(swift, obsoleted: 1.0)
     public func generateGIF(inputGIF data: Data) -> Data? {
-        return EFQRCode.generateGIF(using: self, withIntputGIF: data)
+        return EFQRCode.generateGIF(using: self, withWatermarkGIF: data)
     }
 
     @available(swift, obsoleted: 1.0)
     public func generateGIF(inputGIF data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
         return EFQRCode.generateGIF(
-            using: self, withIntputGIF: data, savingTo: pathToSave,
+            using: self, withWatermarkGIF: data, savingTo: pathToSave,
             delay: delay, loopCount: loopCount,
             useMultipleThreads: useMultipleThreads
         )

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -50,9 +50,11 @@ extension EFQRCodeGenerator {
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIF(watermarkGIF data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
+    public func generateGIF(watermarkGIF data: Data,
+                            delay: Double, loopCount: Int,
+                            useMultipleThreads: Bool) -> Data? {
         return EFQRCode.generateGIF(
-            using: self, withWatermarkGIF: data, savingTo: pathToSave,
+            using: self, withWatermarkGIF: data,
             delay: delay, loopCount: loopCount,
             useMultipleThreads: useMultipleThreads
         )

--- a/Source/EFQRCode+ObjC.swift
+++ b/Source/EFQRCode+ObjC.swift
@@ -45,14 +45,14 @@ extension EFQRCodeGenerator {
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIFWithWatermark(_ data: Data) -> Data? {
-        return EFQRCode.generateGIF(using: self, withWatermark: data)
+    public func generateGIF(inputGIF data: Data) -> Data? {
+        return EFQRCode.generateGIF(using: self, withIntputGIF: data)
     }
 
     @available(swift, obsoleted: 1.0)
-    public func generateGIFWithWatermark(_ data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
+    public func generateGIF(inputGIF data: Data, savingTo pathToSave: URL, delay: Double, loopCount: Int, useMultipleThreads: Bool) -> Data? {
         return EFQRCode.generateGIF(
-            using: self, withWatermark: data, savingTo: pathToSave,
+            using: self, withIntputGIF: data, savingTo: pathToSave,
             delay: delay, loopCount: loopCount,
             useMultipleThreads: useMultipleThreads
         )

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -31,20 +31,18 @@ import CoreGraphics
 import CoreImage
 #endif
 
-@objcMembers
-public class EFQRCode: NSObject {
-    
+public class EFQRCode {
     // MARK: - Recognizer
     #if canImport(CoreImage)
-    public static func recognize(image: CGImage) -> [String]? {
+    public static func recognize(_ image: CGImage) -> [String]? {
         return EFQRCodeRecognizer(image: image).recognize()
     }
     #endif
 
     // MARK: - Generator
     public static func generate(
-        content: String,
-        contentEncoding: String.Encoding = .utf8,
+        _ content: String,
+        encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = .white()!,
         foregroundColor: CGColor = .black()!,
@@ -59,8 +57,7 @@ public class EFQRCode: NSObject {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
     ) -> CGImage? {
-
-        return EFQRCodeGenerator(content: content, encoding: contentEncoding, size: size)
+        return EFQRCodeGenerator(content, encoding: encoding, size: size)
             .withWatermark(watermark, mode: watermarkMode)
             .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
             .withInputCorrectionLevel(inputCorrectionLevel)
@@ -74,7 +71,7 @@ public class EFQRCode: NSObject {
     }
 
     public static func generateGIF(
-        content: String,
+        _ content: String,
         encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = .white()!,
@@ -90,8 +87,7 @@ public class EFQRCode: NSObject {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
     ) -> Data? {
-
-        let generator = EFQRCodeGenerator(content: content, encoding: encoding, size: size)
+        let generator = EFQRCodeGenerator(content, encoding: encoding, size: size)
             .withWatermark(nil, mode: watermarkMode)
             .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
             .withInputCorrectionLevel(inputCorrectionLevel)
@@ -101,37 +97,6 @@ public class EFQRCode: NSObject {
             .withMode(mode)
             .withMagnification(magnification)
             .withForegroundPointOffset(foregroundPointOffset)
-        return EFQRCode.generateGIF(withData: watermark, using: generator)
-    }
-
-    @available(*, deprecated, renamed: "generateGIF(content:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
-    public static func generateWithGIF(
-        content: String,
-        contentEncoding: String.Encoding = .utf8,
-        size: EFIntSize = EFIntSize(width: 600, height: 600),
-        backgroundColor: CGColor = CGColor.white()!,
-        foregroundColor: CGColor = CGColor.black()!,
-        watermark: Data,
-        watermarkMode: EFWatermarkMode = .scaleAspectFill,
-        inputCorrectionLevel: EFInputCorrectionLevel = .h,
-        icon: CGImage? = nil,
-        iconSize: EFIntSize? = nil,
-        allowTransparent: Bool = true,
-        pointShape: EFPointShape = .square,
-        mode: EFQRCodeMode = .none,
-        magnification: EFIntSize? = nil,
-        foregroundPointOffset: CGFloat = 0
-    ) -> Data? {
-        return generateGIF(
-            content: content, encoding: contentEncoding,
-            size: size,
-            backgroundColor: backgroundColor, foregroundColor: foregroundColor,
-            watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
-            inputCorrectionLevel: inputCorrectionLevel,
-            icon: icon, iconSize: iconSize,
-            pointShape: pointShape,
-            mode: mode, magnification: magnification,
-            foregroundPointOffset: foregroundPointOffset
-        )
+        return EFQRCode.generateGIF(using: generator, withWatermark: watermark)
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -53,9 +53,9 @@ public class EFQRCode {
         icon: CGImage? = nil,
         iconSize: EFIntSize? = nil,
         pointShape: EFPointShape = .square,
+        pointOffset: CGFloat = 0,
         mode: EFQRCodeMode? = nil,
-        magnification: EFIntSize? = nil,
-        foregroundPointOffset: CGFloat = 0
+        magnification: EFIntSize? = nil
     ) -> CGImage? {
         return EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(watermark, mode: watermarkMode)
@@ -66,7 +66,7 @@ public class EFQRCode {
             .withPointShape(pointShape)
             .withMode(mode)
             .withMagnification(magnification)
-            .withForegroundPointOffset(foregroundPointOffset)
+            .withPointOffset(pointOffset)
             .generate()
     }
 
@@ -83,9 +83,9 @@ public class EFQRCode {
         icon: CGImage? = nil,
         iconSize: EFIntSize? = nil,
         pointShape: EFPointShape = .square,
+        pointOffset: CGFloat = 0,
         mode: EFQRCodeMode? = nil,
-        magnification: EFIntSize? = nil,
-        foregroundPointOffset: CGFloat = 0
+        magnification: EFIntSize? = nil
     ) -> Data? {
         let generator = EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(nil, mode: watermarkMode)
@@ -96,7 +96,7 @@ public class EFQRCode {
             .withPointShape(pointShape)
             .withMode(mode)
             .withMagnification(magnification)
-            .withForegroundPointOffset(foregroundPointOffset)
+            .withPointOffset(pointOffset)
         return EFQRCode.generateGIF(using: generator, withIntputGIF: watermark)
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -97,6 +97,6 @@ public class EFQRCode {
             .withMode(mode)
             .withMagnification(magnification)
             .withForegroundPointOffset(foregroundPointOffset)
-        return EFQRCode.generateGIF(using: generator, withWatermark: watermark)
+        return EFQRCode.generateGIF(using: generator, withIntputGIF: watermark)
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -43,19 +43,20 @@ public class EFQRCode {
     public static func generate(
         for content: String,
         encoding: String.Encoding = .utf8,
+        inputCorrectionLevel: EFInputCorrectionLevel = .h,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
+        magnification: EFIntSize? = nil,
         backgroundColor: CGColor = .white()!,
         foregroundColor: CGColor = .black()!,
         watermark: CGImage? = nil,
         watermarkMode: EFWatermarkMode = .scaleAspectFill,
         watermarkIsTransparent isWatermarkTransparent: Bool = true,
-        inputCorrectionLevel: EFInputCorrectionLevel = .h,
         icon: CGImage? = nil,
         iconSize: EFIntSize? = nil,
         pointShape: EFPointShape = .square,
         pointOffset: CGFloat = 0,
-        mode: EFQRCodeMode? = nil,
-        magnification: EFIntSize? = nil
+        isTimingPointStyled: Bool = false,
+        mode: EFQRCodeMode? = nil
     ) -> CGImage? {
         return EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(watermark, mode: watermarkMode)
@@ -67,25 +68,27 @@ public class EFQRCode {
             .withMode(mode)
             .withMagnification(magnification)
             .withPointOffset(pointOffset)
+            .withStyledTimingPoint(isTimingPointStyled)
             .generate()
     }
 
     public static func generateGIF(
         for content: String,
         encoding: String.Encoding = .utf8,
+        inputCorrectionLevel: EFInputCorrectionLevel = .h,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
+        magnification: EFIntSize? = nil,
         backgroundColor: CGColor = .white()!,
         foregroundColor: CGColor = .black()!,
         watermark: Data,
         watermarkMode: EFWatermarkMode = .scaleAspectFill,
         watermarkIsTransparent isWatermarkTransparent: Bool = true,
-        inputCorrectionLevel: EFInputCorrectionLevel = .h,
         icon: CGImage? = nil,
         iconSize: EFIntSize? = nil,
         pointShape: EFPointShape = .square,
         pointOffset: CGFloat = 0,
-        mode: EFQRCodeMode? = nil,
-        magnification: EFIntSize? = nil
+        isTimingPointStyled: Bool = false,
+        mode: EFQRCodeMode? = nil
     ) -> Data? {
         let generator = EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(nil, mode: watermarkMode)
@@ -97,6 +100,7 @@ public class EFQRCode {
             .withMode(mode)
             .withMagnification(magnification)
             .withPointOffset(pointOffset)
+            .withStyledTimingPoint(isTimingPointStyled)
         return EFQRCode.generateGIF(using: generator, withIntputGIF: watermark)
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -101,6 +101,6 @@ public enum EFQRCode {
             .withMagnification(magnification)
             .withPointOffset(pointOffset)
             .withStyledTimingPoint(isTimingPointStyled)
-        return EFQRCode.generateGIF(using: generator, withIntputGIF: watermark)
+        return EFQRCode.generateGIF(using: generator, withWatermarkGIF: watermark)
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -34,7 +34,7 @@ import CoreImage
 public enum EFQRCode {
     // MARK: - Recognizer
     #if canImport(CoreImage)
-    public static func recognize(_ image: CGImage) -> [String]? {
+    public static func recognize(_ image: CGImage) -> [String] {
         return EFQRCodeRecognizer(image: image).recognize()
     }
     #endif

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -31,7 +31,7 @@ import CoreGraphics
 import CoreImage
 #endif
 
-public class EFQRCode {
+public enum EFQRCode {
     // MARK: - Recognizer
     #if canImport(CoreImage)
     public static func recognize(_ image: CGImage) -> [String]? {

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -46,34 +46,65 @@ public class EFQRCode: NSObject {
         content: String,
         contentEncoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
-        backgroundColor: CGColor = CGColor.white()!,
-        foregroundColor: CGColor = CGColor.black()!,
+        backgroundColor: CGColor = .white()!,
+        foregroundColor: CGColor = .black()!,
         watermark: CGImage? = nil,
         watermarkMode: EFWatermarkMode = .scaleAspectFill,
+        watermarkIsTransparent isWatermarkTransparent: Bool = true,
         inputCorrectionLevel: EFInputCorrectionLevel = .h,
         icon: CGImage? = nil,
         iconSize: EFIntSize? = nil,
-        allowTransparent: Bool = true,
         pointShape: EFPointShape = .square,
-        mode: EFQRCodeMode = .none,
+        mode: EFQRCodeMode? = nil,
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
-        ) -> CGImage? {
+    ) -> CGImage? {
 
-        let generator = EFQRCodeGenerator(content: content, size: size)
-        generator.setContentEncoding(encoding: contentEncoding)
-        generator.setWatermark(watermark: watermark, mode: watermarkMode)
-        generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
-        generator.setInputCorrectionLevel(inputCorrectionLevel: inputCorrectionLevel)
-        generator.setIcon(icon: icon, size: iconSize ?? EFIntSize(width: size.width / 5, height: size.height / 5))
-        generator.setAllowTransparent(allowTransparent: allowTransparent)
-        generator.setPointShape(pointShape: pointShape)
-        generator.setMode(mode: mode)
-        generator.setMagnification(magnification: magnification)
-        generator.setForegroundPointOffset(foregroundPointOffset: foregroundPointOffset)
-        return generator.generate()
+        return EFQRCodeGenerator(content: content, encoding: contentEncoding, size: size)
+            .withWatermark(watermark, mode: watermarkMode)
+            .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
+            .withInputCorrectionLevel(inputCorrectionLevel)
+            .withIcon(icon, size: iconSize ?? EFIntSize(width: size.width / 5, height: size.height / 5))
+            .withTransparentWatermark(isWatermarkTransparent)
+            .withPointShape(pointShape)
+            .withMode(mode)
+            .withMagnification(magnification)
+            .withForegroundPointOffset(foregroundPointOffset)
+            .generate()
     }
 
+    public static func generateGIF(
+        content: String,
+        encoding: String.Encoding = .utf8,
+        size: EFIntSize = EFIntSize(width: 600, height: 600),
+        backgroundColor: CGColor = .white()!,
+        foregroundColor: CGColor = .black()!,
+        watermark: Data,
+        watermarkMode: EFWatermarkMode = .scaleAspectFill,
+        watermarkIsTransparent isWatermarkTransparent: Bool = true,
+        inputCorrectionLevel: EFInputCorrectionLevel = .h,
+        icon: CGImage? = nil,
+        iconSize: EFIntSize? = nil,
+        pointShape: EFPointShape = .square,
+        mode: EFQRCodeMode? = nil,
+        magnification: EFIntSize? = nil,
+        foregroundPointOffset: CGFloat = 0
+    ) -> Data? {
+
+        let generator = EFQRCodeGenerator(content: content, encoding: encoding, size: size)
+            .withWatermark(nil, mode: watermarkMode)
+            .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
+            .withInputCorrectionLevel(inputCorrectionLevel)
+            .withIcon(icon, size: iconSize ?? EFIntSize(width: size.width / 5, height: size.height / 5))
+            .withTransparentWatermark(isWatermarkTransparent)
+            .withPointShape(pointShape)
+            .withMode(mode)
+            .withMagnification(magnification)
+            .withForegroundPointOffset(foregroundPointOffset)
+        return EFQRCode.generateGIF(withData: watermark, using: generator)
+    }
+
+    @available(*, deprecated, renamed: "generateGIF(content:encoding:size:backgroundColor:foregroundColor:watermark:watermarkMode:inputCorrectionLevel:icon:iconSize:watermarkIsTransparent:pointShape:mode:magnification:foregroundPointOffset:)")
     public static func generateWithGIF(
         content: String,
         contentEncoding: String.Encoding = .utf8,
@@ -90,19 +121,17 @@ public class EFQRCode: NSObject {
         mode: EFQRCodeMode = .none,
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
-        ) -> Data? {
-
-        let generator = EFQRCodeGenerator(content: content, size: size)
-        generator.setContentEncoding(encoding: contentEncoding)
-        generator.setWatermark(watermark: nil, mode: watermarkMode)
-        generator.setColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
-        generator.setInputCorrectionLevel(inputCorrectionLevel: inputCorrectionLevel)
-        generator.setIcon(icon: icon, size: iconSize ?? EFIntSize(width: size.width / 5, height: size.height / 5))
-        generator.setAllowTransparent(allowTransparent: allowTransparent)
-        generator.setPointShape(pointShape: pointShape)
-        generator.setMode(mode: mode)
-        generator.setMagnification(magnification: magnification)
-        generator.setForegroundPointOffset(foregroundPointOffset: foregroundPointOffset)
-        return EFQRCode.generateWithGIF(data: watermark, generator: generator)
+    ) -> Data? {
+        return generateGIF(
+            content: content, encoding: contentEncoding,
+            size: size,
+            backgroundColor: backgroundColor, foregroundColor: foregroundColor,
+            watermark: watermark, watermarkMode: watermarkMode, watermarkIsTransparent: allowTransparent,
+            inputCorrectionLevel: inputCorrectionLevel,
+            icon: icon, iconSize: iconSize,
+            pointShape: pointShape,
+            mode: mode, magnification: magnification,
+            foregroundPointOffset: foregroundPointOffset
+        )
     }
 }

--- a/Source/EFQRCode.swift
+++ b/Source/EFQRCode.swift
@@ -41,7 +41,7 @@ public class EFQRCode {
 
     // MARK: - Generator
     public static func generate(
-        _ content: String,
+        for content: String,
         encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = .white()!,
@@ -57,7 +57,7 @@ public class EFQRCode {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
     ) -> CGImage? {
-        return EFQRCodeGenerator(content, encoding: encoding, size: size)
+        return EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(watermark, mode: watermarkMode)
             .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
             .withInputCorrectionLevel(inputCorrectionLevel)
@@ -71,7 +71,7 @@ public class EFQRCode {
     }
 
     public static func generateGIF(
-        _ content: String,
+        for content: String,
         encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 600, height: 600),
         backgroundColor: CGColor = .white()!,
@@ -87,7 +87,7 @@ public class EFQRCode {
         magnification: EFIntSize? = nil,
         foregroundPointOffset: CGFloat = 0
     ) -> Data? {
-        let generator = EFQRCodeGenerator(content, encoding: encoding, size: size)
+        let generator = EFQRCodeGenerator(content: content, encoding: encoding, size: size)
             .withWatermark(nil, mode: watermarkMode)
             .withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
             .withInputCorrectionLevel(inputCorrectionLevel)

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -193,14 +193,14 @@ public class EFQRCodeGenerator: NSObject {
     }
 
     // Offset of foreground point
-    public var foregroundPointOffset: CGFloat = 0 {
+    public var pointOffset: CGFloat = 0 {
         didSet {
             imageQRCode = nil
         }
     }
     @discardableResult
-    public func withForegroundPointOffset(_ pointOffset: CGFloat) -> EFQRCodeGenerator {
-        self.foregroundPointOffset = pointOffset
+    public func withPointOffset(_ pointOffset: CGFloat) -> EFQRCodeGenerator {
+        self.pointOffset = pointOffset
         return self
     }
 
@@ -462,10 +462,10 @@ public class EFQRCodeGenerator: NSObject {
                     drawPoint(
                         context: context,
                         rect: CGRect(
-                            x: CGFloat(indexXCTM) * scaleX + foregroundPointOffset,
-                            y: CGFloat(indexYCTM) * scaleY + foregroundPointOffset,
-                            width: scaleX - 2 * foregroundPointOffset,
-                            height: scaleY - 2 * foregroundPointOffset
+                            x: CGFloat(indexXCTM) * scaleX + pointOffset,
+                            y: CGFloat(indexYCTM) * scaleY + pointOffset,
+                            width: scaleX - 2 * pointOffset,
+                            height: scaleY - 2 * pointOffset
                         ),
                         isStatic: isStaticPoint
                     )
@@ -573,10 +573,10 @@ public class EFQRCodeGenerator: NSObject {
                         drawPoint(
                             context: context,
                             rect: CGRect(
-                                x: CGFloat(indexXCTM) * scaleX + foregroundPointOffset,
-                                y: CGFloat(indexYCTM) * scaleY + foregroundPointOffset,
-                                width: pointWidthOriX - 2 * foregroundPointOffset,
-                                height: pointWidthOriY - 2 * foregroundPointOffset
+                                x: CGFloat(indexXCTM) * scaleX + pointOffset,
+                                y: CGFloat(indexYCTM) * scaleY + pointOffset,
+                                width: pointWidthOriX - 2 * pointOffset,
+                                height: pointWidthOriY - 2 * pointOffset
                             ),
                             isStatic: true
                         )

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -254,7 +254,7 @@ public class EFQRCodeGenerator: NSObject {
 
     // MARK: - Init
     public init(
-        _ content: String, encoding: String.Encoding = .utf8,
+        content: String, encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 256, height: 256)
     ) {
         self.content = content

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -27,9 +27,10 @@
 #if canImport(CoreImage)
 import CoreImage
 #else
-import CoreGraphics
 import swift_qrcodejs
 #endif
+import CoreGraphics
+import Foundation
 
 // EFQRCode+Create
 @objcMembers

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -232,19 +232,19 @@ public class EFQRCodeGenerator: NSObject {
         return self
     }
 
-    public var isTimingStatic: Bool = true {
+    public var isTimingPointStatic: Bool = true {
         didSet {
             imageQRCode = nil
         }
     }
     @discardableResult
-    public func withStaticTiming(_ isStatic: Bool = true) -> EFQRCodeGenerator {
-        self.isTimingStatic = isStatic
+    public func withStaticTimingPoint(_ isStatic: Bool = true) -> EFQRCodeGenerator {
+        self.isTimingPointStatic = isStatic
         return self
     }
     @discardableResult
-    public func withoutStaticTiming(_ ignoreTiming: Bool = true) -> EFQRCodeGenerator {
-        return withStaticTiming(!ignoreTiming)
+    public func withStyledTimingPoint(_ ignoreTiming: Bool = true) -> EFQRCodeGenerator {
+        return withStaticTimingPoint(!ignoreTiming)
     }
 
     // Cache
@@ -815,7 +815,7 @@ public class EFQRCodeGenerator: NSObject {
             return true
         }
 
-        if isTimingStatic {
+        if isTimingPointStatic {
             // Timing Patterns
             if x == 7 || y == 7 {
                 return true
@@ -863,8 +863,7 @@ public class EFQRCodeGenerator: NSObject {
         return 17 + 4 * version
     }
 
-    /// Recommand magnification
-    @available(*, deprecated)
+    /// Recommend magnification
     public func minMagnificationGreaterThanOrEqualTo(size: CGFloat) -> Int? {
         guard let codes = generateCodes() else {
             return nil

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -298,8 +298,8 @@ public class EFQRCodeGenerator: NSObject {
 
             // Cache size
             minSuitableSize = EFIntSize(
-                width: minSuitableSizeGreaterThanOrEqualTo(size: finalSize.width.cgFloat) ?? finalSize.width,
-                height: minSuitableSizeGreaterThanOrEqualTo(size: finalSize.height.cgFloat) ?? finalSize.height
+                width: minSuitableSize(greaterThanOrEqualTo: finalSize.width.cgFloat) ?? finalSize.width,
+                height: minSuitableSize(greaterThanOrEqualTo: finalSize.height.cgFloat) ?? finalSize.height
             )
 
             // Watermark
@@ -863,8 +863,9 @@ public class EFQRCodeGenerator: NSObject {
         return 17 + 4 * version
     }
 
-    /// Recommend magnification
-    public func minMagnificationGreaterThanOrEqualTo(size: CGFloat) -> Int? {
+    // MARK: - Recommend magnification
+    
+    public func minMagnification(greaterThanOrEqualTo size: CGFloat) -> Int? {
         guard let codes = generateCodes() else {
             return nil
         }
@@ -884,7 +885,7 @@ public class EFQRCodeGenerator: NSObject {
         return nil
     }
 
-    public func maxMagnificationLessThanOrEqualTo(size: CGFloat) -> Int? {
+    public func maxMagnification(lessThanOrEqualTo size: CGFloat) -> Int? {
         guard let codes = generateCodes() else {
             return nil
         }
@@ -908,7 +909,7 @@ public class EFQRCodeGenerator: NSObject {
     }
 
     // Calculate suitable size
-    private func minSuitableSizeGreaterThanOrEqualTo(size: CGFloat) -> Int? {
+    private func minSuitableSize(greaterThanOrEqualTo size: CGFloat) -> Int? {
         guard let codes = generateCodes() else {
             return nil
         }

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -35,6 +35,19 @@ import Foundation
 // EFQRCode+Create
 @objcMembers
 public class EFQRCodeGenerator: NSObject {
+    /// Update the property specified the `keyPath` to have `newValue`.
+    /// - Parameters:
+    ///   - keyPath: a property to update.
+    ///   - newValue: the new value for the specified property.
+    /// - Returns: `self`, allowing chaining.
+    @inlinable
+    @discardableResult
+    public func with<T>(_ keyPath: ReferenceWritableKeyPath<EFQRCodeGenerator, T>,
+                        _ newValue: T) -> EFQRCodeGenerator {
+        self[keyPath: keyPath] = newValue
+        return self
+    }
+
     // MARK: - Parameters
 
     /// Content of QR Code
@@ -62,8 +75,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withContentEncoding(_ encoding: String.Encoding) -> EFQRCodeGenerator {
-        self.contentEncoding = encoding
-        return self
+        return with(\.contentEncoding, encoding)
     }
 
     /// Mode of QR Code
@@ -74,8 +86,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withMode(_ mode: EFQRCodeMode? = nil) -> EFQRCodeGenerator {
-        self.mode = mode
-        return self
+        return with(\.mode, mode)
     }
 
     /// Error-tolerant rate
@@ -92,8 +103,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withInputCorrectionLevel(_ inputCorrectionLevel: EFInputCorrectionLevel) -> EFQRCodeGenerator {
-        self.inputCorrectionLevel = inputCorrectionLevel
-        return self
+        return with(\.inputCorrectionLevel, inputCorrectionLevel)
     }
 
     /// Size of QR Code
@@ -104,8 +114,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withSize(_ size: EFIntSize) -> EFQRCodeGenerator {
-        self.size = size
-        return self
+        return with(\.size, size)
     }
 
     /// Magnification of QRCode compare with the minimum size,
@@ -117,8 +126,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withMagnification(_ magnification: EFIntSize?) -> EFQRCodeGenerator {
-        self.magnification = magnification
-        return self
+        return with(\.magnification, magnification)
     }
 
     /// backgroundColor
@@ -137,18 +145,17 @@ public class EFQRCodeGenerator: NSObject {
     @discardableResult
     @objc(withCIColorsForBackgroundColor:foregroundColor:)
     public func withColors(backgroundColor: CIColor, foregroundColor: CIColor) -> EFQRCodeGenerator {
-        self.backgroundColor = backgroundColor.cgColor() ?? CGColor.white()!
-        self.foregroundColor = foregroundColor.cgColor() ?? CGColor.black()!
-        return self
+        return withColors(backgroundColor: backgroundColor.cgColor() ?? CGColor.white()!,
+                          foregroundColor: foregroundColor.cgColor() ?? CGColor.black()!)
     }
     #endif
 
     @discardableResult
     @objc(withCGColorsForBackgroundColor:foregroundColor:)
     public func withColors(backgroundColor: CGColor, foregroundColor: CGColor) -> EFQRCodeGenerator {
-        self.backgroundColor = backgroundColor
-        self.foregroundColor = foregroundColor
         return self
+            .with(\.backgroundColor, backgroundColor)
+            .with(\.foregroundColor, foregroundColor)
     }
 
     /// Icon in the middle of QR Code
@@ -165,9 +172,9 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withIcon(_ icon: CGImage?, size: EFIntSize?) -> EFQRCodeGenerator {
-        self.icon = icon
-        self.iconSize = size
         return self
+            .with(\.icon, icon)
+            .with(\.iconSize, size)
     }
 
     /// Watermark
@@ -200,8 +207,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withPointOffset(_ pointOffset: CGFloat) -> EFQRCodeGenerator {
-        self.pointOffset = pointOffset
-        return self
+        return with(\.pointOffset, pointOffset)
     }
 
     /// If false (default), area of watermark will be transparent with alpha 0.
@@ -212,8 +218,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withOpaqueWatermark(_ isWatermarkOpaque: Bool = true) -> EFQRCodeGenerator {
-        self.isWatermarkOpaque = isWatermarkOpaque
-        return self
+        return with(\.isWatermarkOpaque, isWatermarkOpaque)
     }
     @discardableResult
     public func withTransparentWatermark(_ isTransparent: Bool = true) -> EFQRCodeGenerator {
@@ -228,8 +233,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withPointShape(_ pointShape: EFPointShape) -> EFQRCodeGenerator {
-        self.pointShape = pointShape
-        return self
+        return with(\.pointShape, pointShape)
     }
 
     public var isTimingPointStatic: Bool = true {
@@ -239,8 +243,7 @@ public class EFQRCodeGenerator: NSObject {
     }
     @discardableResult
     public func withStaticTimingPoint(_ isStatic: Bool = true) -> EFQRCodeGenerator {
-        self.isTimingPointStatic = isStatic
-        return self
+        return with(\.isTimingPointStatic, isStatic)
     }
     @discardableResult
     public func withStyledTimingPoint(_ ignoreTiming: Bool = true) -> EFQRCodeGenerator {
@@ -389,7 +392,7 @@ public class EFQRCodeGenerator: NSObject {
     private func getForegroundColor() -> CGColor {
         switch mode {
         case .binarization:
-            return CGColor.black()!
+            return .black()!
         default:
             return foregroundColor
         }
@@ -398,7 +401,7 @@ public class EFQRCodeGenerator: NSObject {
     private func getBackgroundColor() -> CGColor {
         switch mode {
         case .binarization:
-            return CGColor.white()!
+            return .white()!
         default:
             return backgroundColor
         }
@@ -410,7 +413,8 @@ public class EFQRCodeGenerator: NSObject {
         codes: [[Bool]],
         colorBack: CIColor,
         colorFront: CIColor,
-        size: EFIntSize) -> CGImage? {
+        size: EFIntSize
+    ) -> CGImage? {
         guard let colorCGFront = colorFront.cgColor() else {
             return nil
         }
@@ -422,7 +426,8 @@ public class EFQRCodeGenerator: NSObject {
         codes: [[Bool]],
         colorBack colorCGBack: CGColor? = nil,
         colorFront colorCGFront: CGColor,
-        size: EFIntSize) -> CGImage? {
+        size: EFIntSize
+    ) -> CGImage? {
         let codeSize = codes.count
         
         let scaleX = size.width.cgFloat / CGFloat(codeSize)
@@ -607,8 +612,11 @@ public class EFQRCodeGenerator: NSObject {
         image: CGImage,
         colorBack: CIColor,
         mode: EFWatermarkMode,
-        size: CGSize) {
-        drawWatermarkImage(context: context, image: image, colorBack: colorBack.cgColor(), mode: mode, size: size)
+        size: CGSize
+    ) {
+        drawWatermarkImage(context: context, image: image,
+                           colorBack: colorBack.cgColor(),
+                           mode: mode, size: size)
     }
     #endif
 
@@ -653,30 +661,40 @@ public class EFQRCodeGenerator: NSObject {
             finalOrigin = CGPoint(x: size.width - imageSize.width, y: 0)
         case .center:
             finalSize = imageSize
-            finalOrigin = CGPoint(x: (size.width - imageSize.width) / 2.0, y: (size.height - imageSize.height) / 2.0)
+            finalOrigin = CGPoint(x: (size.width - imageSize.width) / 2.0,
+                                  y: (size.height - imageSize.height) / 2.0)
         case .left:
             finalSize = imageSize
             finalOrigin = CGPoint(x: 0, y: (size.height - imageSize.height) / 2.0)
         case .right:
             finalSize = imageSize
-            finalOrigin = CGPoint(x: size.width - imageSize.width, y: (size.height - imageSize.height) / 2.0)
+            finalOrigin = CGPoint(x: size.width - imageSize.width,
+                                  y: (size.height - imageSize.height) / 2.0)
         case .top:
             finalSize = imageSize
-            finalOrigin = CGPoint(x: (size.width - imageSize.width) / 2.0, y: size.height - imageSize.height)
+            finalOrigin = CGPoint(x: (size.width - imageSize.width) / 2.0,
+                                  y: size.height - imageSize.height)
         case .topLeft:
             finalSize = imageSize
             finalOrigin = CGPoint(x: 0, y: size.height - imageSize.height)
         case .topRight:
             finalSize = imageSize
-            finalOrigin = CGPoint(x: size.width - imageSize.width, y: size.height - imageSize.height)
+            finalOrigin = CGPoint(x: size.width - imageSize.width,
+                                  y: size.height - imageSize.height)
         case .scaleAspectFill:
-            let scale = max(size.width / imageSize.width, size.height / imageSize.height)
-            finalSize = CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
-            finalOrigin = CGPoint(x: (size.width - finalSize.width) / 2.0, y: (size.height - finalSize.height) / 2.0)
+            let scale = max(size.width / imageSize.width,
+                            size.height / imageSize.height)
+            finalSize = CGSize(width: imageSize.width * scale,
+                               height: imageSize.height * scale)
+            finalOrigin = CGPoint(x: (size.width - finalSize.width) / 2.0,
+                                  y: (size.height - finalSize.height) / 2.0)
         case .scaleAspectFit:
-            let scale = max(imageSize.width / size.width, imageSize.height / size.height)
-            finalSize = CGSize(width: imageSize.width / scale, height: imageSize.height / scale)
-            finalOrigin = CGPoint(x: (size.width - finalSize.width) / 2.0, y: (size.height - finalSize.height) / 2.0)
+            let scale = max(imageSize.width / size.width,
+                            imageSize.height / size.height)
+            finalSize = CGSize(width: imageSize.width / scale,
+                               height: imageSize.height / scale)
+            finalOrigin = CGPoint(x: (size.width - finalSize.width) / 2.0,
+                                  y: (size.height - finalSize.height) / 2.0)
         case .scaleToFill:
             break
         }
@@ -754,8 +772,13 @@ public class EFQRCodeGenerator: NSObject {
         let finalContentEncoding = contentEncoding
 
         guard let tryQRImagePixels = CIImage
-                .generateQRCode(finalContent, using: finalContentEncoding, inputCorrectionLevel: finalInputCorrectionLevel)?
-                .cgImage()?.pixels() else {
+                .generateQRCode(
+                    finalContent, using: finalContentEncoding,
+                    inputCorrectionLevel: finalInputCorrectionLevel
+                )?
+                .cgImage()?
+                .pixels()
+        else {
             print("Warning: Content too large.")
             return nil
         }
@@ -831,8 +854,9 @@ public class EFQRCodeGenerator: NSObject {
         }
     }
 
-    // Alignment Pattern Locations
-    // http://stackoverflow.com/questions/13238704/calculating-the-position-of-qr-code-alignment-patterns
+    /// [Alignment Pattern Locations](
+    /// http://stackoverflow.com/questions/13238704/calculating-the-position-of-qr-code-alignment-patterns
+    /// )
     private func getAlignmentPatternLocations(version: Int) -> [Int]? {
         if version == 1 {
             return nil
@@ -847,18 +871,18 @@ public class EFQRCodeGenerator: NSObject {
         var coords = [6]
 
         // divs-2 down to 0, inclusive
-        coords += ( 0...(divs - 2) ).lazy.map { i in
+        coords += ( 0...(divs - 2) ).map { i in
             size - 7 - (divs - 2 - i) * step
         }
         return coords
     }
 
-    // QRCode version
+    /// QRCode version
     private func getVersion(size: Int) -> Int {
         return (size - 21) / 4 + 1
     }
 
-    // QRCode size
+    /// QRCode size
     private func getSize(version: Int) -> Int {
         return 17 + 4 * version
     }
@@ -874,10 +898,10 @@ public class EFQRCodeGenerator: NSObject {
         let baseMagnification = max(1, Int(size / CGFloat(codes.count)))
         for offset in 0 ... 3 {
             let tempMagnification = baseMagnification + offset
-            if CGFloat(Int(tempMagnification) * codes.count) >= size {
+            if CGFloat(tempMagnification * codes.count) >= size {
                 if finalWatermark == nil {
                     return tempMagnification
-                } else if tempMagnification % 3 == 0 {
+                } else if tempMagnification.isMultiple(of: 3) {
                     return tempMagnification
                 }
             }
@@ -900,7 +924,7 @@ public class EFQRCodeGenerator: NSObject {
             if CGFloat(tempMagnification * codes.count) <= size {
                 if finalWatermark == nil {
                     return tempMagnification
-                } else if tempMagnification % 3 == 0 {
+                } else if tempMagnification.isMultiple(of: 3) {
                     return tempMagnification
                 }
             }
@@ -917,7 +941,7 @@ public class EFQRCodeGenerator: NSObject {
         let baseSuitableSize = Int(size)
         for offset in codes.indices {
             let tempSuitableSize = baseSuitableSize + offset
-            if tempSuitableSize % codes.count == 0 {
+            if tempSuitableSize.isMultiple(of: codes.count) {
                 return tempSuitableSize
             }
         }

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -37,172 +37,287 @@ public class EFQRCodeGenerator: NSObject {
 
     // MARK: - Parameters
 
-    // Content of QR Code
-    private var content: String? {
+    /// Content of QR Code
+    public var content: String? {
         didSet {
             imageQRCode = nil
             imageCodes = nil
         }
     }
-    public func setContent(content: String) {
+    @discardableResult
+    public func withContent(_ content: String, encoding: String.Encoding? = nil) -> EFQRCodeGenerator {
         self.content = content
+        if let encoding = encoding {
+            return withContentEncoding(encoding)
+        }
+        return self
+    }
+    @available(*, deprecated, renamed: "withContent(_:)")
+    public func setContent(content: String) {
+        withContent(content)
     }
     
-    // Encoding of the content
-    private var contentEncoding: String.Encoding = .utf8 {
+    /// Encoding of the content
+    public var contentEncoding: String.Encoding = .utf8 {
         didSet {
             imageQRCode = nil
             imageCodes = nil
         }
     }
-    public func setContentEncoding(encoding: String.Encoding) {
+    @discardableResult
+    public func withContentEncoding(_ encoding: String.Encoding) -> EFQRCodeGenerator {
         self.contentEncoding = encoding
+        return self
+    }
+    @available(*, deprecated, renamed: "withContentEncoding(_:)")
+    public func setContentEncoding(encoding: String.Encoding) {
+        withContentEncoding(encoding)
     }
 
-    // Mode of QR Code
-    private var mode: EFQRCodeMode = .none {
+    /// Mode of QR Code
+    public var mode: EFQRCodeMode? = nil {
         didSet {
             imageQRCode = nil
         }
     }
-    public func setMode(mode: EFQRCodeMode) {
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withoutMode() -> EFQRCodeGenerator {
+        return withMode(nil)
+    }
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withGrayscaleMode() -> EFQRCodeGenerator {
+        return withMode(.grayscale)
+    }
+    @discardableResult
+    @available(swift, obsoleted: 1.0, renamed: "withMode")
+    public func withBinarizationMode(threshold: CGFloat) -> EFQRCodeGenerator {
+        return withMode(.binarization(threshold: threshold))
+    }
+    @discardableResult
+    public func withMode(_ mode: EFQRCodeMode? = nil) -> EFQRCodeGenerator {
         self.mode = mode
+        return self
+    }
+    @available(*, deprecated, renamed: "withMode(_:)")
+    public func setMode(mode: EFQRCodeMode) {
+        withMode(mode)
     }
 
-    // Error-tolerant rate
-    // L 7%
-    // M 15%
-    // Q 25%
-    // H 30%(Default)
-    private var inputCorrectionLevel: EFInputCorrectionLevel = .h {
+    /// Error-tolerant rate
+    ///
+    /// - L 7%
+    /// - M 15%
+    /// - Q 25%
+    /// - H 30%(Default)
+    public var inputCorrectionLevel: EFInputCorrectionLevel = .h {
         didSet {
             imageQRCode = nil
             imageCodes = nil
         }
     }
-    public func setInputCorrectionLevel(inputCorrectionLevel: EFInputCorrectionLevel) {
+    @discardableResult
+    public func withInputCorrectionLevel(_ inputCorrectionLevel: EFInputCorrectionLevel) -> EFQRCodeGenerator {
         self.inputCorrectionLevel = inputCorrectionLevel
+        return self
+    }
+    @available(*, deprecated, renamed: "withInputCorrectionLevel(_:)")
+    public func setInputCorrectionLevel(inputCorrectionLevel: EFInputCorrectionLevel) {
+        withInputCorrectionLevel(inputCorrectionLevel)
     }
 
-    // Size of QR Code
-    private var size: EFIntSize = EFIntSize(width: 256, height: 256) {
+    /// Size of QR Code
+    public var size: EFIntSize = EFIntSize(width: 256, height: 256) {
         didSet {
             imageQRCode = nil
         }
     }
-    public func setSize(size: EFIntSize) {
+    @discardableResult
+    public func withSize(_ size: EFIntSize) -> EFQRCodeGenerator {
         self.size = size
+        return self
+    }
+    @available(*, deprecated, renamed: "withSize(_:)")
+    public func setSize(size: EFIntSize) {
+        withSize(size)
     }
 
-    // Magnification of QRCode compare with the minimum size,
-    // (Parameter size will be ignored if magnification is not nil).
-    private var magnification: EFIntSize? {
+    /// Magnification of QRCode compare with the minimum size,
+    /// (Parameter size will be ignored if magnification is not nil).
+    public var magnification: EFIntSize? {
         didSet {
             imageQRCode = nil
         }
     }
-    public func setMagnification(magnification: EFIntSize?) {
+    @discardableResult
+    public func withMagnification(_ magnification: EFIntSize?) -> EFQRCodeGenerator {
         self.magnification = magnification
+        return self
+    }
+    @available(*, deprecated, renamed: "withMagnification(_:)")
+    public func setMagnification(magnification: EFIntSize?) {
+        withMagnification(magnification)
     }
 
-    // backgroundColor
-    private var backgroundColor: CGColor = CGColor.white()! {
+    /// backgroundColor
+    public var backgroundColor: CGColor = CGColor.white()! {
         didSet {
             imageQRCode = nil
         }
     }
-    // foregroundColor
-    private var foregroundColor: CGColor = CGColor.black()! {
+    /// foregroundColor
+    public var foregroundColor: CGColor = CGColor.black()! {
         didSet {
             imageQRCode = nil
         }
     }
     #if canImport(CoreImage)
-    @nonobjc public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
+    @discardableResult
+    @objc(setCIColorsWithBackgroundColor:foregroundColor:)
+    public func withColors(backgroundColor: CIColor, foregroundColor: CIColor) -> EFQRCodeGenerator {
         self.backgroundColor = backgroundColor.cgColor() ?? CGColor.white()!
         self.foregroundColor = foregroundColor.cgColor() ?? CGColor.black()!
+        return self
+    }
+
+    @nonobjc
+    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
+    public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
+        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
     }
     #endif
 
-    public func setColors(backgroundColor: CGColor, foregroundColor: CGColor) {
+    @discardableResult
+    public func withColors(backgroundColor: CGColor, foregroundColor: CGColor) -> EFQRCodeGenerator {
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
+        return self
+    }
+    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
+    public func setColors(backgroundColor: CGColor, foregroundColor: CGColor) {
+        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
     }
 
-    // Icon in the middle of QR Code
-    private var icon: CGImage? = nil {
+    /// Icon in the middle of QR Code
+    public var icon: CGImage? = nil {
         didSet {
             imageQRCode = nil
         }
     }
-    // Size of icon
-    private var iconSize: EFIntSize? = nil {
+    /// Size of icon
+    public var iconSize: EFIntSize? = nil {
         didSet {
             imageQRCode = nil
         }
     }
+    @discardableResult
+    public func withIcon(_ icon: CGImage?, size: EFIntSize?) -> EFQRCodeGenerator {
+        self.icon = icon
+        self.iconSize = size
+        return self
+    }
+    @available(*, deprecated, renamed: "withIcon(_:size:)")
     public func setIcon(icon: CGImage?, size: EFIntSize?) {
         self.icon = icon
         self.iconSize = size
     }
 
-    // Watermark
-    private var watermark: CGImage? = nil {
+    /// Watermark
+    public var watermark: CGImage? = nil {
         didSet {
             imageQRCode = nil
         }
     }
-    // Mode of watermark
-    private var watermarkMode: EFWatermarkMode = .scaleAspectFill {
+    /// Mode of watermark
+    public var watermarkMode: EFWatermarkMode = .scaleAspectFill {
         didSet {
             imageQRCode = nil
         }
     }
-    public func setWatermark(watermark: CGImage?, mode: EFWatermarkMode? = nil) {
+    @discardableResult
+    public func withWatermark(_ watermark: CGImage?, mode: EFWatermarkMode? = nil) -> EFQRCodeGenerator {
         self.watermark = watermark
 
         if let mode = mode {
             self.watermarkMode = mode
         }
+        return self
+    }
+    @available(*, deprecated, renamed: "withWatermark(_:mode:)")
+    public func setWatermark(watermark: CGImage?, mode: EFWatermarkMode? = nil) {
+        withWatermark(watermark, mode: mode)
     }
 
     // Offset of foreground point
-    private var foregroundPointOffset: CGFloat = 0 {
+    public var foregroundPointOffset: CGFloat = 0 {
         didSet {
             imageQRCode = nil
         }
     }
+    @discardableResult
+    public func withForegroundPointOffset(_ pointOffset: CGFloat) -> EFQRCodeGenerator {
+        self.foregroundPointOffset = pointOffset
+        return self
+    }
+    @available(*, deprecated, renamed: "withForegroundPointOffset(_:)")
     public func setForegroundPointOffset(foregroundPointOffset: CGFloat) {
-        self.foregroundPointOffset = foregroundPointOffset
+        withForegroundPointOffset(foregroundPointOffset)
     }
 
-    // Alpha 0 area of watermark will transparent
-    private var allowTransparent: Bool = true {
+    /// If false (default), area of watermark will be transparent with alpha 0.
+    public var isWatermarkOpaque: Bool = false {
         didSet {
             imageQRCode = nil
         }
     }
+    @discardableResult
+    public func withOpaqueWatermark(_ isWatermarkOpaque: Bool) -> EFQRCodeGenerator {
+        self.isWatermarkOpaque = isWatermarkOpaque
+        return self
+    }
+    @discardableResult
+    public func withTransparentWatermark(_ isTransparent: Bool) -> EFQRCodeGenerator {
+        return withOpaqueWatermark(!isTransparent)
+    }
+    @available(*, deprecated, renamed: "withTransparentWatermark(_:)")
     public func setAllowTransparent(allowTransparent: Bool) {
-        self.allowTransparent = allowTransparent
+        withTransparentWatermark(allowTransparent)
     }
 
     // Shape of foreground point
-    private var pointShape: EFPointShape = .square {
+    public var pointShape: EFPointShape = .square {
         didSet {
             imageQRCode = nil
         }
     }
-    public func setPointShape(pointShape: EFPointShape) {
+    @discardableResult
+    public func withPointShape(_ pointShape: EFPointShape) -> EFQRCodeGenerator {
         self.pointShape = pointShape
+        return self
+    }
+    @available(*, deprecated, renamed: "withPointShape(_:)")
+    public func setPointShape(pointShape: EFPointShape) {
+        withPointShape(pointShape)
     }
 
-    private var ignoreTiming: Bool = false {
+    public var isTimingStatic: Bool = true {
         didSet {
             imageQRCode = nil
         }
     }
+    @discardableResult
+    public func withStaticTiming(_ isStatic: Bool) -> EFQRCodeGenerator {
+        self.isTimingStatic = isStatic
+        return self
+    }
+    @discardableResult
+    public func withoutStaticTiming(_ ignoreTiming: Bool) -> EFQRCodeGenerator {
+        return withStaticTiming(!ignoreTiming)
+    }
+    @available(*, deprecated, renamed: "withoutStaticTiming(_:)")
     public func setIgnoreTiming(ignoreTiming: Bool) {
-        self.ignoreTiming = ignoreTiming
+        withoutStaticTiming(!ignoreTiming)
     }
 
     // Cache
@@ -212,10 +327,11 @@ public class EFQRCodeGenerator: NSObject {
 
     // MARK: - Init
     public init(
-        content: String,
+        content: String, encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 256, height: 256)
     ) {
         self.content = content
+        self.contentEncoding = encoding
         self.size = size
     }
 
@@ -270,11 +386,12 @@ public class EFQRCodeGenerator: NSObject {
                     size: finalSize.cgSize
                 )
                 // Draw QR Code
-                if let tryFrontImage = createQRCodeImageTransparent(
-                    codes: codes,
+                if let tryFrontImage = createTransparentQRCodeImage(
+                    from: codes,
                     colorBack: finalBackgroundColor,
                     colorFront: finalForegroundColor,
-                    size: minSuitableSize) {
+                    size: minSuitableSize
+                ) {
                     context.draw(tryFrontImage, in: CGRect(origin: .zero, size: finalSize.cgSize))
                 }
             } else {
@@ -288,7 +405,8 @@ public class EFQRCodeGenerator: NSObject {
                     codes: codes,
                     colorBack: finalBackgroundColor,
                     colorFront: finalForegroundColor,
-                    size: minSuitableSize) {
+                    size: minSuitableSize
+                ) {
                     context.draw(tryImage, in: CGRect(origin: .zero, size: finalSize.cgSize))
                 }
             }
@@ -323,18 +441,18 @@ public class EFQRCodeGenerator: NSObject {
 
         // Mode apply
         switch mode {
-        case .grayscale:
+        case .grayscale?:
             if let tryModeImage = result?.grayscale {
                 result = tryModeImage
             }
-        case .binarization(let threshold):
+        case .binarization(let threshold)?:
             if let tryModeImage = result?.binarization(
                 threshold: threshold,
                 foregroundColor: foregroundColor,
                 backgroundColor: backgroundColor) {
                 result = tryModeImage
             }
-        case .none:
+        case nil, EFQRCodeMode.none?:
             break
         }
 
@@ -433,23 +551,25 @@ public class EFQRCodeGenerator: NSObject {
 
     #if canImport(CoreImage)
     /// Create Colorful QR Image
-    private func createQRCodeImageTransparent(
-        codes: [[Bool]],
+    private func createTransparentQRCodeImage(
+        from codes: [[Bool]],
         colorBack: CIColor,
         colorFront: CIColor,
-        size: EFIntSize) -> CGImage? {
-        guard let colorCGBack = colorBack.cgColor(), let colorCGFront = colorFront.cgColor() else {
-            return nil
-        }
-        return createQRCodeImageTransparent(codes: codes, colorBack: colorCGBack, colorFront: colorCGFront, size: size)
+        size: EFIntSize
+    ) -> CGImage? {
+        guard let colorCGBack = colorBack.cgColor(),
+              let colorCGFront = colorFront.cgColor()
+        else { return nil }
+        return createTransparentQRCodeImage(from: codes, colorBack: colorCGBack, colorFront: colorCGFront, size: size)
     }
     #endif
 
-    private func createQRCodeImageTransparent(
-        codes: [[Bool]],
+    private func createTransparentQRCodeImage(
+        from codes: [[Bool]],
         colorBack colorCGBack: CGColor,
         colorFront colorCGFront: CGColor,
-        size: EFIntSize) -> CGImage? {
+        size: EFIntSize
+    ) -> CGImage? {
         let codeSize = codes.count
 
         let scaleX = size.width.cgFloat / CGFloat(codeSize)
@@ -570,13 +690,14 @@ public class EFQRCodeGenerator: NSObject {
         image: CGImage,
         colorBack: CGColor?,
         mode: EFWatermarkMode,
-        size: CGSize) {
+        size: CGSize
+    ) {
         // BGColor
         if let tryColor = colorBack {
             context.setFillColor(tryColor)
             context.fill(CGRect(origin: .zero, size: size))
         }
-        if allowTransparent {
+        if !isWatermarkOpaque {
             guard let codes = generateCodes() else {
                 return
             }
@@ -585,7 +706,7 @@ public class EFQRCodeGenerator: NSObject {
                 colorBack: getBackgroundColor(),
                 colorFront: getForegroundColor(),
                 size: minSuitableSize
-                ) {
+            ) {
                 context.draw(tryCGImage, in: CGRect(origin: .zero, size: size))
             }
         }
@@ -767,7 +888,7 @@ public class EFQRCodeGenerator: NSObject {
             return true
         }
 
-        if !ignoreTiming {
+        if isTimingStatic {
             // Timing Patterns
             if x == 7 || y == 7 {
                 return true

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -85,7 +85,7 @@ public class EFQRCodeGenerator: NSObject {
         }
     }
     @discardableResult
-    public func withMode(_ mode: EFQRCodeMode? = nil) -> EFQRCodeGenerator {
+    public func withMode(_ mode: EFQRCodeMode?) -> EFQRCodeGenerator {
         return with(\.mode, mode)
     }
 

--- a/Source/EFQRCodeGenerator.swift
+++ b/Source/EFQRCodeGenerator.swift
@@ -34,7 +34,6 @@ import swift_qrcodejs
 // EFQRCode+Create
 @objcMembers
 public class EFQRCodeGenerator: NSObject {
-
     // MARK: - Parameters
 
     /// Content of QR Code
@@ -52,11 +51,7 @@ public class EFQRCodeGenerator: NSObject {
         }
         return self
     }
-    @available(*, deprecated, renamed: "withContent(_:)")
-    public func setContent(content: String) {
-        withContent(content)
-    }
-    
+
     /// Encoding of the content
     public var contentEncoding: String.Encoding = .utf8 {
         didSet {
@@ -69,10 +64,6 @@ public class EFQRCodeGenerator: NSObject {
         self.contentEncoding = encoding
         return self
     }
-    @available(*, deprecated, renamed: "withContentEncoding(_:)")
-    public func setContentEncoding(encoding: String.Encoding) {
-        withContentEncoding(encoding)
-    }
 
     /// Mode of QR Code
     public var mode: EFQRCodeMode? = nil {
@@ -81,28 +72,9 @@ public class EFQRCodeGenerator: NSObject {
         }
     }
     @discardableResult
-    @available(swift, obsoleted: 1.0, renamed: "withMode")
-    public func withoutMode() -> EFQRCodeGenerator {
-        return withMode(nil)
-    }
-    @discardableResult
-    @available(swift, obsoleted: 1.0, renamed: "withMode")
-    public func withGrayscaleMode() -> EFQRCodeGenerator {
-        return withMode(.grayscale)
-    }
-    @discardableResult
-    @available(swift, obsoleted: 1.0, renamed: "withMode")
-    public func withBinarizationMode(threshold: CGFloat) -> EFQRCodeGenerator {
-        return withMode(.binarization(threshold: threshold))
-    }
-    @discardableResult
     public func withMode(_ mode: EFQRCodeMode? = nil) -> EFQRCodeGenerator {
         self.mode = mode
         return self
-    }
-    @available(*, deprecated, renamed: "withMode(_:)")
-    public func setMode(mode: EFQRCodeMode) {
-        withMode(mode)
     }
 
     /// Error-tolerant rate
@@ -122,10 +94,6 @@ public class EFQRCodeGenerator: NSObject {
         self.inputCorrectionLevel = inputCorrectionLevel
         return self
     }
-    @available(*, deprecated, renamed: "withInputCorrectionLevel(_:)")
-    public func setInputCorrectionLevel(inputCorrectionLevel: EFInputCorrectionLevel) {
-        withInputCorrectionLevel(inputCorrectionLevel)
-    }
 
     /// Size of QR Code
     public var size: EFIntSize = EFIntSize(width: 256, height: 256) {
@@ -137,10 +105,6 @@ public class EFQRCodeGenerator: NSObject {
     public func withSize(_ size: EFIntSize) -> EFQRCodeGenerator {
         self.size = size
         return self
-    }
-    @available(*, deprecated, renamed: "withSize(_:)")
-    public func setSize(size: EFIntSize) {
-        withSize(size)
     }
 
     /// Magnification of QRCode compare with the minimum size,
@@ -154,10 +118,6 @@ public class EFQRCodeGenerator: NSObject {
     public func withMagnification(_ magnification: EFIntSize?) -> EFQRCodeGenerator {
         self.magnification = magnification
         return self
-    }
-    @available(*, deprecated, renamed: "withMagnification(_:)")
-    public func setMagnification(magnification: EFIntSize?) {
-        withMagnification(magnification)
     }
 
     /// backgroundColor
@@ -174,29 +134,20 @@ public class EFQRCodeGenerator: NSObject {
     }
     #if canImport(CoreImage)
     @discardableResult
-    @objc(setCIColorsWithBackgroundColor:foregroundColor:)
+    @objc(withCIColorsForBackgroundColor:foregroundColor:)
     public func withColors(backgroundColor: CIColor, foregroundColor: CIColor) -> EFQRCodeGenerator {
         self.backgroundColor = backgroundColor.cgColor() ?? CGColor.white()!
         self.foregroundColor = foregroundColor.cgColor() ?? CGColor.black()!
         return self
     }
-
-    @nonobjc
-    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
-    public func setColors(backgroundColor: CIColor, foregroundColor: CIColor) {
-        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
-    }
     #endif
 
     @discardableResult
+    @objc(withCGColorsForBackgroundColor:foregroundColor:)
     public func withColors(backgroundColor: CGColor, foregroundColor: CGColor) -> EFQRCodeGenerator {
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
         return self
-    }
-    @available(*, deprecated, renamed: "withColors(backgroundColor:foregroundColor:)")
-    public func setColors(backgroundColor: CGColor, foregroundColor: CGColor) {
-        withColors(backgroundColor: backgroundColor, foregroundColor: foregroundColor)
     }
 
     /// Icon in the middle of QR Code
@@ -216,11 +167,6 @@ public class EFQRCodeGenerator: NSObject {
         self.icon = icon
         self.iconSize = size
         return self
-    }
-    @available(*, deprecated, renamed: "withIcon(_:size:)")
-    public func setIcon(icon: CGImage?, size: EFIntSize?) {
-        self.icon = icon
-        self.iconSize = size
     }
 
     /// Watermark
@@ -244,10 +190,6 @@ public class EFQRCodeGenerator: NSObject {
         }
         return self
     }
-    @available(*, deprecated, renamed: "withWatermark(_:mode:)")
-    public func setWatermark(watermark: CGImage?, mode: EFWatermarkMode? = nil) {
-        withWatermark(watermark, mode: mode)
-    }
 
     // Offset of foreground point
     public var foregroundPointOffset: CGFloat = 0 {
@@ -260,10 +202,6 @@ public class EFQRCodeGenerator: NSObject {
         self.foregroundPointOffset = pointOffset
         return self
     }
-    @available(*, deprecated, renamed: "withForegroundPointOffset(_:)")
-    public func setForegroundPointOffset(foregroundPointOffset: CGFloat) {
-        withForegroundPointOffset(foregroundPointOffset)
-    }
 
     /// If false (default), area of watermark will be transparent with alpha 0.
     public var isWatermarkOpaque: Bool = false {
@@ -272,17 +210,13 @@ public class EFQRCodeGenerator: NSObject {
         }
     }
     @discardableResult
-    public func withOpaqueWatermark(_ isWatermarkOpaque: Bool) -> EFQRCodeGenerator {
+    public func withOpaqueWatermark(_ isWatermarkOpaque: Bool = true) -> EFQRCodeGenerator {
         self.isWatermarkOpaque = isWatermarkOpaque
         return self
     }
     @discardableResult
-    public func withTransparentWatermark(_ isTransparent: Bool) -> EFQRCodeGenerator {
+    public func withTransparentWatermark(_ isTransparent: Bool = true) -> EFQRCodeGenerator {
         return withOpaqueWatermark(!isTransparent)
-    }
-    @available(*, deprecated, renamed: "withTransparentWatermark(_:)")
-    public func setAllowTransparent(allowTransparent: Bool) {
-        withTransparentWatermark(allowTransparent)
     }
 
     // Shape of foreground point
@@ -296,10 +230,6 @@ public class EFQRCodeGenerator: NSObject {
         self.pointShape = pointShape
         return self
     }
-    @available(*, deprecated, renamed: "withPointShape(_:)")
-    public func setPointShape(pointShape: EFPointShape) {
-        withPointShape(pointShape)
-    }
 
     public var isTimingStatic: Bool = true {
         didSet {
@@ -307,17 +237,13 @@ public class EFQRCodeGenerator: NSObject {
         }
     }
     @discardableResult
-    public func withStaticTiming(_ isStatic: Bool) -> EFQRCodeGenerator {
+    public func withStaticTiming(_ isStatic: Bool = true) -> EFQRCodeGenerator {
         self.isTimingStatic = isStatic
         return self
     }
     @discardableResult
-    public func withoutStaticTiming(_ ignoreTiming: Bool) -> EFQRCodeGenerator {
+    public func withoutStaticTiming(_ ignoreTiming: Bool = true) -> EFQRCodeGenerator {
         return withStaticTiming(!ignoreTiming)
-    }
-    @available(*, deprecated, renamed: "withoutStaticTiming(_:)")
-    public func setIgnoreTiming(ignoreTiming: Bool) {
-        withoutStaticTiming(!ignoreTiming)
     }
 
     // Cache
@@ -327,7 +253,7 @@ public class EFQRCodeGenerator: NSObject {
 
     // MARK: - Init
     public init(
-        content: String, encoding: String.Encoding = .utf8,
+        _ content: String, encoding: String.Encoding = .utf8,
         size: EFIntSize = EFIntSize(width: 256, height: 256)
     ) {
         self.content = content
@@ -511,8 +437,8 @@ public class EFQRCodeGenerator: NSObject {
                     let finalX = indexX + 1
                     let finalY = indexY + 1
                     if !((finalX == 7 && finalY == 7)
-                        || (finalX == 7 && finalY == (codeSize - 8))
-                        || (finalX == (codeSize - 8) && finalY == 7)) {
+                            || (finalX == 7 && finalY == (codeSize - 8))
+                            || (finalX == (codeSize - 8) && finalY == 7)) {
                         points.append(CGPoint(x: finalX, y: finalY))
                     }
                 }
@@ -593,8 +519,8 @@ public class EFQRCodeGenerator: NSObject {
                     let finalX = indexX + 1
                     let finalY = indexY + 1
                     if !((finalX == 7 && finalY == 7)
-                        || (finalX == 7 && finalY == (codeSize - 8))
-                        || (finalX == (codeSize - 8) && finalY == 7)) {
+                            || (finalX == 7 && finalY == (codeSize - 8))
+                            || (finalX == (codeSize - 8) && finalY == 7)) {
                         points.append(CGPoint(x: finalX, y: finalY))
                     }
                 }
@@ -781,8 +707,8 @@ public class EFQRCodeGenerator: NSObject {
         let startPoint = CGPoint(x: drawingRect.minX, y: drawingRect.midY)
         // the other point of diamond
         let otherPoints = [CGPoint(x: drawingRect.midX, y: drawingRect.maxY),
-                      CGPoint(x: drawingRect.maxX, y: drawingRect.midY),
-                      CGPoint(x: drawingRect.midX, y: drawingRect.minY)]
+                           CGPoint(x: drawingRect.maxX, y: drawingRect.midY),
+                           CGPoint(x: drawingRect.midX, y: drawingRect.minY)]
         
         path.move(to: startPoint)
         for point in otherPoints {
@@ -795,16 +721,16 @@ public class EFQRCodeGenerator: NSObject {
 
     private func drawPoint(context: CGContext, rect: CGRect, isStatic: Bool = false) {
         switch pointShape {
-            case .circle:
-                context.fillEllipse(in: rect)
-            case .diamond:
-                if isStatic {
-                    context.fill(rect)
-                } else {
-                    fillDiamond(context: context, rect: rect)
-                }
-            case .square:
+        case .circle:
+            context.fillEllipse(in: rect)
+        case .diamond:
+            if isStatic {
                 context.fill(rect)
+            } else {
+                fillDiamond(context: context, rect: rect)
+            }
+        case .square:
+            context.fill(rect)
         }
     }
 
@@ -827,10 +753,10 @@ public class EFQRCodeGenerator: NSObject {
         let finalContentEncoding = contentEncoding
 
         guard let tryQRImagePixels = CIImage
-            .generateQRCode(finalContent, using: finalContentEncoding, inputCorrectionLevel: finalInputCorrectionLevel)?
-            .cgImage()?.pixels() else {
-                print("Warning: Content too large.")
-                return nil
+                .generateQRCode(finalContent, using: finalContentEncoding, inputCorrectionLevel: finalInputCorrectionLevel)?
+                .cgImage()?.pixels() else {
+            print("Warning: Content too large.")
+            return nil
         }
         return tryQRImagePixels
     }
@@ -937,6 +863,7 @@ public class EFQRCodeGenerator: NSObject {
     }
 
     /// Recommand magnification
+    @available(*, deprecated)
     public func minMagnificationGreaterThanOrEqualTo(size: CGFloat) -> Int? {
         guard let codes = generateCodes() else {
             return nil

--- a/Source/EFQRCodeMode.swift
+++ b/Source/EFQRCodeMode.swift
@@ -25,7 +25,6 @@
 //  THE SOFTWARE.
 
 import CoreGraphics
-import Foundation
 
 public enum EFQRCodeMode {
     @available(*, deprecated, message: "Use `nil` instead.")

--- a/Source/EFQRCodeMode.swift
+++ b/Source/EFQRCodeMode.swift
@@ -28,6 +28,7 @@ import CoreGraphics
 import Foundation
 
 public enum EFQRCodeMode {
+    @available(*, deprecated, message: "Use `nil` instead.")
     case none
     case grayscale
     case binarization(threshold: CGFloat)

--- a/Source/EFQRCodeRecognizer.swift
+++ b/Source/EFQRCodeRecognizer.swift
@@ -29,14 +29,10 @@ import CoreImage
 
 @objcMembers
 public class EFQRCodeRecognizer: NSObject {
-
-    private var image: CGImage? {
+    public var image: CGImage? {
         didSet {
             contentArray = nil
         }
-    }
-    public func setImage(image: CGImage?) {
-        self.image = image
     }
 
     private var contentArray: [String]?

--- a/Source/EFQRCodeRecognizer.swift
+++ b/Source/EFQRCodeRecognizer.swift
@@ -29,7 +29,7 @@ import CoreImage
 
 @objcMembers
 public class EFQRCodeRecognizer: NSObject {
-    public var image: CGImage? {
+    public var image: CGImage {
         didSet {
             contentArray = nil
         }
@@ -41,21 +41,20 @@ public class EFQRCodeRecognizer: NSObject {
         self.image = image
     }
 
-    public func recognize() -> [String]? {
+    public func recognize() -> [String] {
         if nil == contentArray {
             contentArray = getQRString()
         }
-        return contentArray
+        return contentArray!
     }
 
-    // Get QRCodes from image
-    private func getQRString() -> [String]? {
-        guard let finalImage = image else {
-            return nil
-        }
-        let result = finalImage.ciImage().recognizeQRCode(options: [CIDetectorAccuracy: CIDetectorAccuracyHigh])
-        if result.isEmpty {
-            return finalImage.grayscale?.ciImage().recognizeQRCode(
+    /// Get QRCodes from image
+    private func getQRString() -> [String] {
+        let result = image.ciImage().recognizeQRCode(
+            options: [CIDetectorAccuracy: CIDetectorAccuracyHigh]
+        )
+        if result.isEmpty, let grayscaleImage = image.grayscale {
+            return grayscaleImage.ciImage().recognizeQRCode(
                 options: [CIDetectorAccuracy: CIDetectorAccuracyLow]
             )
         }

--- a/Source/EFUIntPixel.swift
+++ b/Source/EFUIntPixel.swift
@@ -24,18 +24,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import CoreGraphics
-
-public struct EFUIntPixel {
+struct EFUIntPixel {
     public var red: UInt8 = 0
     public var green: UInt8 = 0
     public var blue: UInt8 = 0
     public var alpha: UInt8 = 0
-
-    init(red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) {
-        self.red = red
-        self.green = green
-        self.blue = blue
-        self.alpha = alpha
-    }
 }

--- a/Source/EFUIntPixel.swift
+++ b/Source/EFUIntPixel.swift
@@ -25,8 +25,8 @@
 //  THE SOFTWARE.
 
 struct EFUIntPixel {
-    public var red: UInt8 = 0
-    public var green: UInt8 = 0
-    public var blue: UInt8 = 0
-    public var alpha: UInt8 = 0
+    var red: UInt8 = 0
+    var green: UInt8 = 0
+    var blue: UInt8 = 0
+    var alpha: UInt8 = 0
 }

--- a/Source/EFWatermarkMode.swift
+++ b/Source/EFWatermarkMode.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import CoreGraphics
 import Foundation
 
 @objc public enum EFWatermarkMode: Int {

--- a/Source/NSColor+.swift
+++ b/Source/NSColor+.swift
@@ -28,7 +28,6 @@
 import AppKit
 
 extension NSColor {
-
     func ciColor() -> CIColor {
         return cgColor.ciColor()
     }
@@ -37,13 +36,12 @@ extension NSColor {
         return self.cgColor
     }
     
-    static func white(white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> NSColor {
+    static func white(_ white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> NSColor {
         return self.init(white: white, alpha: alpha)
     }
     
-    static func black(black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> NSColor {
-        let white: CGFloat = 1.0 - black
-        return Self.white(white: white, alpha: alpha)
+    static func black(_ black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> NSColor {
+        return white(1.0 - black, alpha: alpha)
     }
 }
 #endif

--- a/Source/NSImage+.swift
+++ b/Source/NSImage+.swift
@@ -29,7 +29,6 @@ import AppKit
 import CoreImage
 
 extension NSImage {
-    
     func ciImage() -> CIImage? {
         return self.tiffRepresentation(using: .none, factor: 0).flatMap(CIImage.init)
     }

--- a/Source/UIColor+.swift
+++ b/Source/UIColor+.swift
@@ -48,7 +48,6 @@ extension UIColor {
 }
 
 extension UIColor {
-
     #if canImport(CoreImage)
     func ciColor() -> CIColor {
         return CIColor(color: self)
@@ -59,13 +58,12 @@ extension UIColor {
         return self.cgColor
     }
     
-    static func white(white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> UIColor {
+    static func white(_ white: CGFloat = 1.0, alpha: CGFloat = 1.0) -> UIColor {
         return self.init(white: white, alpha: alpha)
     }
     
-    static func black(black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> UIColor {
-        let white: CGFloat = 1.0 - black
-        return Self.white(white: white, alpha: alpha)
+    static func black(_ black: CGFloat = 1.0, alpha: CGFloat = 1.0) -> UIColor {
+        return white(1.0 - black, alpha: alpha)
     }
 }
 #endif

--- a/Source/UIImage+.swift
+++ b/Source/UIImage+.swift
@@ -35,7 +35,6 @@ import CoreImage
 #endif
 
 extension UIImage {
-
     #if canImport(CoreImage)
     func ciImage() -> CIImage? {
         return self.ciImage ?? CIImage(image: self)
@@ -43,13 +42,12 @@ extension UIImage {
     #endif
 
     func cgImage() -> CGImage? {
-        let rtnValue: CGImage? = self.cgImage
+        let rtnValue = self.cgImage
         #if canImport(CoreImage)
-        if nil == rtnValue {
-            return ciImage?.cgImage()
-        }
-        #endif
+        return rtnValue ?? ciImage?.cgImage()
+        #else
         return rtnValue
+        #endif
     }
 }
 
@@ -72,7 +70,6 @@ extension UIImage {
 }
 
 extension UIImage {
-
     func cornerRadiused(radius: CGFloat) -> UIImage? {
         let imageLayer: CALayer = CALayer()
         imageLayer.frame = CGRect(x: 0, y: 0, width: self.size.width, height: self.size.height)

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -13,6 +13,16 @@
 @import AppKit;
 #define EFColor NSColor
 #define EFImage NSImage
+@interface NSImage (EFQRCode)
+-(CGImageRef) CGImage;
+@end
+
+@implementation NSImage (EFQRCode)
+-(CGImageRef) CGImage {
+    CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)[self TIFFRepresentation], NULL);
+    return CGImageSourceCreateImageAtIndex(source, 0, NULL);
+}
+@end
 #else
 @import UIKit;
 #define EFColor UIColor
@@ -24,17 +34,16 @@
 @end
 
 @implementation ObjCTests
-
 - (CGImageRef) getImage {
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSString *path = [bundle pathForResource:@"eyrefree" ofType:@"png"];
-    EFImage *image = [[EFImage alloc] initWithContentsOfFile:path];
-#if TARGET_OS_OSX
-    CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)[image TIFFRepresentation], NULL);
-    return CGImageSourceCreateImageAtIndex(source, 0, NULL);
+#if SWIFT_PACKAGE
+    NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
 #else
-    return [image CGImage];
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
 #endif
+    NSString *path = [bundle pathForResource:@"eyrefree" ofType:@"png"];
+    XCTAssertNotNil(path);
+    EFImage *image = [[EFImage alloc] initWithContentsOfFile:path];
+    return [image CGImage];
 }
 
 - (void)testGenerator {

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -57,7 +57,7 @@
     [g withIcon:[self getImage] size:nil];
     [g withWatermark:[self getImage] mode: EFWatermarkModeBottom];
     [g withTransparentWatermark:YES];
-    [g withForegroundPointOffset: 0];
+    [g withPointOffset: 0];
     [g withStaticTiming: YES];
     CGImageRef testResult = [g generate];
     XCTAssertNotEqual(testResult, NULL);

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -56,6 +56,7 @@
     [g withMagnification:nil];
     [g withIcon:[self getImage] size:nil];
     [g withWatermark:[self getImage] mode: EFWatermarkModeBottom];
+    [g withOpaqueWatermark:YES];
     [g withTransparentWatermark:YES];
     [g withPointOffset: 0];
     [g withStaticTimingPoint:YES];

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -1,0 +1,97 @@
+//
+//  ObjCTests.m
+//  EFQRCode
+//
+//  Created by Apollo Zhu on 11/25/20.
+//  Copyright © 2020 EyreFree. All rights reserved.
+//
+
+@import XCTest;
+@import EFQRCode;
+
+#if TARGET_OS_OSX
+@import AppKit;
+#define EFColor NSColor
+#define EFImage NSImage
+#else
+@import UIKit;
+#define EFColor UIColor
+#define EFImage UIImage
+#endif
+
+@interface ObjCTests : XCTestCase
+
+@end
+
+@implementation ObjCTests
+
+- (CGImageRef) getImage {
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *path = [bundle pathForResource:@"eyrefree" ofType:@"png"];
+    EFImage *image = [[EFImage alloc] initWithContentsOfFile:path];
+#if TARGET_OS_OSX
+    CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)[image TIFFRepresentation], NULL);
+    return CGImageSourceCreateImageAtIndex(source, 0, NULL);
+#else
+    return [image CGImage];
+#endif
+}
+
+- (void)testGenerator {
+    NSString *content = @"https://github.com/EFPrefix/EFQRCode";
+    EFIntSize *size = [[EFIntSize alloc] initWithWidth:15 height:15];
+    EFQRCodeGenerator *g = [[EFQRCodeGenerator alloc] initWithContent: content
+                                                             encoding: NSUTF8StringEncoding
+                                                                 size: size];
+    [g withContent:content encoding: NSUTF8StringEncoding];
+    [g withSize:size];
+    [g withBinarizationModeWithThreshold:0.3];
+    [g withGrayscaleMode];
+    [g withNormalMode];
+    [g withCGColorsForBackgroundColor:[EFColor grayColor].CGColor
+                      foregroundColor:[EFColor blackColor].CGColor];
+    [g withCIColorsForBackgroundColor:[CIColor whiteColor]
+                      foregroundColor:[CIColor blackColor]];
+    [g withInputCorrectionLevel:EFInputCorrectionLevelQ];
+    [g withMagnification:nil];
+    [g withIcon:[self getImage] size:nil];
+    [g withWatermark:[self getImage] mode: EFWatermarkModeBottom];
+    [g withTransparentWatermark:YES];
+    [g withForegroundPointOffset: 0];
+    [g withStaticTiming: YES];
+    CGImageRef testResult = [g generate];
+    XCTAssertNotEqual(testResult, NULL);
+}
+
+- (void)testGeneratorGIF {
+    NSString *content = @"https://github.com/EFPrefix/EFQRCode";
+    EFIntSize *size = [[EFIntSize alloc] initWithWidth:15 height:15];
+    EFQRCodeGenerator *g = [[EFQRCodeGenerator alloc] initWithContent: content
+                                                             encoding: NSUTF8StringEncoding
+                                                                 size: size];
+    NSData *watermark = [content dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *data = [g generateGIFWithWatermark: watermark];
+#warning TODO: Generate Actual GIF
+    NSLog(@"%@", data);
+}
+
+- (void)testRecognizer {
+    // This is an example of EFQRCodeGenerator test case.
+    NSString *content = @"https://github.com/EFPrefix/EFQRCode";
+    EFIntSize *size = [[EFIntSize alloc] initWithWidth:256 height:256];
+    EFQRCodeGenerator *g = [[EFQRCodeGenerator alloc] initWithContent:content
+                                                             encoding:NSUTF8StringEncoding
+                                                                 size:size];
+    CGImageRef testResult = [g generate];
+    XCTAssertNotEqual(testResult, NULL, "testResult is nil!");
+
+    // This is an example of EFQRCodeRecognizer test case.
+    EFQRCodeRecognizer *r = [[EFQRCodeRecognizer alloc] initWithImage:testResult];
+    r.image = testResult;
+    NSArray<NSString *> *testResultArray = [r recognize];
+    XCTAssertNotNil(testResultArray, "testResultArray is nil!");
+    XCTAssertGreaterThan([testResultArray count], 0, "testResultArray has no result!");
+    XCTAssertEqualObjects(testResultArray[0], content, "testResultArray is wrong!");
+}
+
+@end

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -70,7 +70,7 @@
                                                              encoding: NSUTF8StringEncoding
                                                                  size: size];
     NSData *watermark = [content dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *data = [g generateGIFWithWatermark: watermark];
+    NSData *data = [g generateGIFWithInputGIF: watermark];
 #warning TODO: Generate Actual GIF
     NSLog(@"%@", data);
 }

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -81,7 +81,7 @@
                                                              encoding: NSUTF8StringEncoding
                                                                  size: size];
     NSData *watermark = [content dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *data = [g generateGIFWithInputGIF: watermark];
+    NSData *data = [g generateGIFWithWatermarkGIF: watermark];
 #warning TODO: Generate Actual GIF
     NSLog(@"%@", data);
 }

--- a/Tests/ObjCTests.m
+++ b/Tests/ObjCTests.m
@@ -58,7 +58,8 @@
     [g withWatermark:[self getImage] mode: EFWatermarkModeBottom];
     [g withTransparentWatermark:YES];
     [g withPointOffset: 0];
-    [g withStaticTiming: YES];
+    [g withStaticTimingPoint:YES];
+    [g withStyledTimingPoint:YES];
     CGImageRef testResult = [g generate];
     XCTAssertNotEqual(testResult, NULL);
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -27,27 +27,25 @@
 import XCTest
 @testable import EFQRCode
 
+#if canImport(UIKit)
+import UIKit
+typealias EFImage = UIImage
+typealias EFColor = UIColor
+#else
+import AppKit
+typealias EFImage = NSImage
+typealias EFColor = NSColor
+#endif
+
 class Tests: XCTestCase {
-
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
-    func getImage(name: String) -> CGImage? {
-        if let filePath = Bundle.init(for: self.classForCoder).path(forResource: "eyrefree", ofType: "png") {
-            #if os(macOS)
-            return NSImage(contentsOfFile: filePath)?.cgImage()
-            #else
-            return UIImage(contentsOfFile: filePath)?.cgImage()
-            #endif
-        }
-        return nil
+    func getImage(named name: String = "eyrefree") -> CGImage {
+        #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+        #else
+        let bundle = Bundle(for: type(of: self))
+        #endif
+        let filePath = bundle.path(forResource: name, ofType: "png")!
+        return EFImage(contentsOfFile: filePath)!.cgImage()!
     }
 
     func testExample1() {
@@ -58,17 +56,18 @@ class Tests: XCTestCase {
             size: EFIntSize(width: 256, height: 256)
         )
         generator.setMode(mode: .none)
-        generator.setColors(backgroundColor: CIColor.white(), foregroundColor: CIColor.black())
+        generator.setColors(backgroundColor: CIColor.white(),
+                            foregroundColor: CIColor.black())
         generator.setInputCorrectionLevel(inputCorrectionLevel: .h)
         generator.setMagnification(magnification: EFIntSize(width: 6, height: 6))
         let testResult = generator.generate()
-        XCTAssert(testResult != nil, "testResult is nil!")
+        XCTAssertNotNil(testResult, "testResult is nil!")
 
         // This is an example of EFQRCodeRecognizer test case.
         let testResultArray = EFQRCode.recognize(image: testResult!)
-        XCTAssert(testResultArray != nil, "testResultArray is nil!")
-        XCTAssert(testResultArray!.count > 0, "testResultArray has no result!")
-        XCTAssert(testResultArray![0] == content, "testResultArray is wrong!")
+        XCTAssertNotNil(testResultArray, "testResultArray is nil!")
+        XCTAssertFalse(testResultArray!.isEmpty, "testResultArray has no result!")
+        XCTAssertEqual(testResultArray![0], content, "testResultArray is wrong!")
     }
 
     func testExample2() {
@@ -79,17 +78,18 @@ class Tests: XCTestCase {
             size: EFIntSize(width: 999, height: 999)
         )
         generator.setMode(mode: .none)
-        generator.setColors(backgroundColor: CIColor.white(), foregroundColor: CIColor.black())
+        generator.setColors(backgroundColor: CIColor.white(),
+                            foregroundColor: CIColor.black())
         generator.setInputCorrectionLevel(inputCorrectionLevel: .l)
         generator.setMagnification(magnification: nil)
         let testResult = generator.generate()
-        XCTAssert(testResult != nil, "testResult is nil!")
+        XCTAssertNotNil(testResult, "testResult is nil!")
 
         // This is an example of EFQRCodeRecognizer test case.
         let testResultArray = EFQRCode.recognize(image: testResult!)
-        XCTAssert(testResultArray != nil, "testResultArray is nil!")
-        XCTAssert(testResultArray!.count > 0, "testResultArray has no result!")
-        XCTAssert(testResultArray![0] == content, "testResultArray is wrong!")
+        XCTAssertNotNil(testResultArray, "testResultArray is nil!")
+        XCTAssertFalse(testResultArray!.isEmpty, "testResultArray has no result!")
+        XCTAssertEqual(testResultArray![0], content, "testResultArray is wrong!")
     }
 
     func testExample3() {
@@ -100,23 +100,18 @@ class Tests: XCTestCase {
             size: EFIntSize(width: 1024, height: 1024)
         )
         generator.setMode(mode: .none)
-        generator.setColors(backgroundColor: {
-            #if os(macOS)
-            return NSColor.gray.ciColor()
-            #else
-            return UIColor.gray.ciColor()
-            #endif
-        }(), foregroundColor: CIColor.black())
+        generator.setColors(backgroundColor: EFColor.gray.ciColor(),
+                            foregroundColor: CIColor.black())
         generator.setInputCorrectionLevel(inputCorrectionLevel: .m)
         generator.setMagnification(magnification: nil)
         let testResult = generator.generate()
-        XCTAssert(testResult != nil, "testResult is nil!")
+        XCTAssertNotNil(testResult, "testResult is nil!")
 
         // This is an example of EFQRCodeRecognizer test case.
         let testResultArray = EFQRCode.recognize(image: testResult!)
-        XCTAssert(testResultArray != nil, "testResultArray is nil!")
-        XCTAssert(testResultArray!.count > 0, "testResultArray has no result!")
-        XCTAssert(testResultArray![0] == content, "testResultArray is wrong!")
+        XCTAssertNotNil(testResultArray, "testResultArray is nil!")
+        XCTAssertFalse(testResultArray!.isEmpty, "testResultArray has no result!")
+        XCTAssertEqual(testResultArray![0], content, "testResultArray is wrong!")
     }
 
     func testExample4() {
@@ -127,39 +122,34 @@ class Tests: XCTestCase {
             size: EFIntSize(width: 15, height: 15)
         )
         generator.setMode(mode: .none)
-        generator.setColors(backgroundColor: {
-            #if os(macOS)
-            return NSColor.gray.ciColor()
-            #else
-            return UIColor.red.ciColor()
-            #endif
-        }(), foregroundColor: CIColor.black())
+        generator.setColors(backgroundColor: EFColor.gray.ciColor(),
+                            foregroundColor: CIColor.black())
         generator.setInputCorrectionLevel(inputCorrectionLevel: .q)
         generator.setMagnification(magnification: nil)
-        generator.setIcon(icon: getImage(name: "eyrefree"), size: nil)
-        generator.setWatermark(watermark: getImage(name: "eyrefree"), mode: .bottom)
+        generator.setIcon(icon: getImage(), size: nil)
+        generator.setWatermark(watermark: getImage(), mode: .bottom)
         generator.setForegroundPointOffset(foregroundPointOffset: 0)
         generator.setAllowTransparent(allowTransparent: true)
         let testResult = generator.generate()
-        XCTAssert(testResult != nil, "testResult is nil!")
+        XCTAssertNotNil(testResult, "testResult is nil!")
     }
 
     // CGColor
     func testExampleCGColorExtension() {
-        XCTAssert(CGColor.white() != nil, "CGColor.EFWhite() should not be nil!")
-        XCTAssert(CGColor.black() != nil, "CGColor.EFBlack() should not be nil!")
+        XCTAssertNotNil(CGColor.white(), "CGColor.EFWhite() should not be nil!")
+        XCTAssertNotNil(CGColor.black(), "CGColor.EFBlack() should not be nil!")
     }
 
     // CGSize
     func testExampleCGSizeExtension() {
         let size = CGSize(width: 111.1, height: 888.8)
-        XCTAssert(size.width.int == 111, "size.widthInt() should be 111!")
-        XCTAssert(size.height.int == 888, "size.heightInt() should be 888!")
+        XCTAssertEqual(size.width.int, 111, "size.widthInt() should be 111!")
+        XCTAssertEqual(size.height.int, 888, "size.heightInt() should be 888!")
     }
 
     // EFQRCode
     func testExampleEFQRCode() {
         let testResult = EFQRCode.generate(content: "https://github.com/EFPrefix/EFQRCode")
-        XCTAssert(testResult != nil, "testResult is nil!")
+        XCTAssertNotNil(testResult, "testResult is nil!")
     }
 }


### PR DESCRIPTION
> See [V6 API Announcement](https://github.com/EFPrefix/EFQRCode/discussions/115) for details

- Enable chaining methods for builder pattern
   + Mostly automatically migrate-able:
      * Use <kbd>control</kbd> + <kbd>option</kbd> + <kbd>command</kbd> + <kbd>F</kbd> to apply all fix-its in scope
      * Need to manually update `EFQRCodeMode.none` to `EFQRCodeMode?.none`, i.e. `nil`
      * Need to manually update recognition code to handle empty array instead of handling optional and/or empty array
   + Variables are now public for old, non-chaining behavior
      * Use `EFQRCodeGenerator.with<T>(_: ReferenceWritableKeyPath<Self, T>,  _: T) -> Self` to set property directly and chain invocations
   + Old APIs (`EFQRCode+Migration-v6.swift`) are `deprecated`, and should be marked as `obsoleted`/`unavailable` with v7 release, and the file completely deleted with v8 release.
- Objective-C Support (closes #92)
   - `EFQRCodeGenerator`, `EFQRCodeRecognizer` are now equally available in Swift/ObjC, and `EFQRCode` will be Swift only
   - Added unit tests to ensure API availability
- `EFUIntPixel` appears to be not an active part of the existing public API, so it will no longer be
   - Note: this will most likely resurface in v7?
- Officially drop `pathToSave` from GIF generation API