### PR TITLE
Fix build on Xcode 14.3 beta

### DIFF
--- a/Source/EFIntSize.swift
+++ b/Source/EFIntSize.swift
@@ -25,6 +25,7 @@
 //  THE SOFTWARE.
 
 import CoreGraphics
+import Foundation
 
 /// A structure that contains width and height values.
 ///


### PR DESCRIPTION
I tried to build EFQRCode on Xcode 14.3 beta. Then this error is raised.

```swift
$ swift build
Fetching https://github.com/ApolloZhu/swift_qrcodejs.git
Fetched https://github.com/ApolloZhu/swift_qrcodejs.git (0.99s)
Computing version for https://github.com/ApolloZhu/swift_qrcodejs.git
Computed https://github.com/ApolloZhu/swift_qrcodejs.git at 2.2.2 (0.64s)
Creating working copy for https://github.com/ApolloZhu/swift_qrcodejs.git
Working copy of https://github.com/ApolloZhu/swift_qrcodejs.git resolved at 2.2.2
Building for debugging...
error: emit-module command failed with exit code 1 (use -v to see invocation)
/Users/giginet/.ghq/github.com/EFPrefix/EFQRCode/Source/EFIntSize.swift:32:1: error: @objcMembers attribute used without importing module 'Foundation'
@objcMembers
^~~~~~~~~~~~
/Users/giginet/.ghq/github.com/EFPrefix/EFQRCode/Source/EFIntSize.swift:32:1: error: @objcMembers attribute used without importing module 'Foundation'
@objcMembers
^~~~~~~~~~~~
/Users/giginet/.ghq/github.com/EFPrefix/EFQRCode/Source/EFIntSize.swift:32:1: error: @objcMembers attribute used without importing module 'Foundation'
@objcMembers
^~~~~~~~~~~~
[23/23] Compiling EFQRCode UIImage+.swift
```

I added `import Foundation` to avoid implicit importing.