### PR TITLE
update Package.resolved to point to v2.3.1 of swift_qrcodejs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/EFPrefix/swift_qrcodejs.git",
         "state": {
           "branch": null,
-          "revision": "817ba220a2eba840bae888e7eeb11207bec05f8c",
-          "version": "2.3.0"
+          "revision": "d1605333f7edac39b4518538ef4f2638fdd2e4d6",
+          "version": "2.3.1"
         }
       }
     ]


### PR DESCRIPTION
- v2.3.0 `817ba220a2eba840bae888e7eeb11207bec05f8c` is not part of a tree in swift_qrcodejs
- updated to v2.3.1 `d1605333f7edac39b4518538ef4f2638fdd2e4d6`